### PR TITLE
Apply shuffle_options when serving MCQ options (#38)

### DIFF
--- a/purplex/problems_app/handlers/mcq/handler.py
+++ b/purplex/problems_app/handlers/mcq/handler.py
@@ -12,6 +12,7 @@ comparing the selected answer(s) to the correct one(s).
 
 import json
 import logging
+import random
 from typing import TYPE_CHECKING, Any, Union
 
 from .. import register_handler
@@ -265,6 +266,10 @@ class MCQHandler(ActivityHandler):
         # Ensure we have the actual McqProblem instance with MCQ-specific fields
         mcq = _ensure_mcq_problem(problem)
 
+        options_to_display = list(mcq.options)
+        if mcq.shuffle_options:
+            random.shuffle(options_to_display)
+
         return {
             "display": {
                 "show_reference_code": False,
@@ -280,7 +285,7 @@ class MCQHandler(ActivityHandler):
                         "id": str(opt.get("id", "")),
                         "text": opt.get("text", ""),
                     }
-                    for opt in mcq.options
+                    for opt in options_to_display
                 ],
             },
             "hints": {

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1093,6 +1093,98 @@ class TestMCQConfig:
         assert config["supports"]["test_cases"] is False
 
 
+class TestMCQShuffleOptions:
+    """Tests for MCQ option shuffling behavior."""
+
+    @pytest.fixture
+    def handler(self):
+        """Create an MCQ handler instance."""
+        return get_handler("mcq")
+
+    @pytest.fixture
+    def mock_problem_no_shuffle(self):
+        """MCQ problem with shuffle_options=False."""
+        problem = MagicMock()
+        problem.options = [
+            {"id": "1", "text": "Option A", "is_correct": False},
+            {"id": "2", "text": "Option B", "is_correct": True},
+            {"id": "3", "text": "Option C", "is_correct": False},
+            {"id": "4", "text": "Option D", "is_correct": False},
+        ]
+        problem.allow_multiple = False
+        problem.shuffle_options = False
+        return problem
+
+    @pytest.fixture
+    def mock_problem_shuffle(self):
+        """MCQ problem with shuffle_options=True."""
+        problem = MagicMock()
+        problem.options = [
+            {"id": "1", "text": "Option A", "is_correct": False},
+            {"id": "2", "text": "Option B", "is_correct": True},
+            {"id": "3", "text": "Option C", "is_correct": False},
+            {"id": "4", "text": "Option D", "is_correct": False},
+        ]
+        problem.allow_multiple = False
+        problem.shuffle_options = True
+        return problem
+
+    def test_no_shuffle_preserves_order(self, handler, mock_problem_no_shuffle):
+        """When shuffle_options=False, options stay in original order."""
+        config = handler.get_problem_config(mock_problem_no_shuffle)
+        option_ids = [opt["id"] for opt in config["input"]["options"]]
+        assert option_ids == ["1", "2", "3", "4"]
+
+    def test_shuffle_preserves_all_options(self, handler, mock_problem_shuffle):
+        """When shuffle_options=True, all options are still present."""
+        config = handler.get_problem_config(mock_problem_shuffle)
+        option_ids = sorted(opt["id"] for opt in config["input"]["options"])
+        assert option_ids == ["1", "2", "3", "4"]
+
+    def test_shuffle_changes_order(self, handler, mock_problem_shuffle):
+        """When shuffle_options=True, order should differ from original at least sometimes."""
+        original_order = ["1", "2", "3", "4"]
+        saw_different_order = False
+        # With 4 options, probability of same order is 1/24 per call.
+        # After 10 calls, probability of never seeing a different order is (1/24)^10.
+        for _ in range(10):
+            config = handler.get_problem_config(mock_problem_shuffle)
+            option_ids = [opt["id"] for opt in config["input"]["options"]]
+            if option_ids != original_order:
+                saw_different_order = True
+                break
+        assert saw_different_order, "Options were never shuffled after 10 attempts"
+
+    def test_shuffle_does_not_mutate_original(self, handler, mock_problem_shuffle):
+        """Shuffling should not mutate the problem's original options list."""
+        original_options = [dict(opt) for opt in mock_problem_shuffle.options]
+        handler.get_problem_config(mock_problem_shuffle)
+        assert mock_problem_shuffle.options == original_options
+
+    def test_shuffle_does_not_leak_is_correct(self, handler, mock_problem_shuffle):
+        """Shuffled options should not expose is_correct to frontend."""
+        config = handler.get_problem_config(mock_problem_shuffle)
+        for opt in config["input"]["options"]:
+            assert "is_correct" not in opt
+            assert "explanation" not in opt
+
+    def test_shuffle_with_multiselect(self, handler):
+        """Shuffling works correctly with allow_multiple=True."""
+        problem = MagicMock()
+        problem.options = [
+            {"id": "a", "text": "A", "is_correct": True},
+            {"id": "b", "text": "B", "is_correct": True},
+            {"id": "c", "text": "C", "is_correct": False},
+        ]
+        problem.allow_multiple = True
+        problem.shuffle_options = True
+
+        config = handler.get_problem_config(problem)
+        option_ids = sorted(opt["id"] for opt in config["input"]["options"])
+        assert option_ids == ["a", "b", "c"]
+        assert config["input"]["type"] == "checkbox"
+
+
 class TestMCQSerializeResult:
     """Tests for MCQ result serialization."""
 


### PR DESCRIPTION
## Summary
- **Fixes #38**: The `shuffle_options` boolean on `McqProblem` was stored but never applied — options always returned in DB insertion order
- `get_problem_config()` now checks `mcq.shuffle_options` and randomizes option order before serving to the frontend
- Grading is unaffected since it matches by option ID, not position

## Changes
- `purplex/problems_app/handlers/mcq/handler.py`: shuffle options list when `shuffle_options=True` (3-line fix)
- `tests/unit/test_handlers.py`: 6 new tests in `TestMCQShuffleOptions` covering order preservation, shuffling, non-mutation, no secret leakage, and multi-select

## Test plan
- [x] `shuffle_options=False` preserves original option order
- [x] `shuffle_options=True` produces a different order (verified over 10 attempts)
- [x] All options are present after shuffling (no drops)
- [x] Original `mcq.options` list is not mutated
- [x] `is_correct` and `explanation` are not leaked to frontend
- [x] Shuffling works with `allow_multiple=True` (checkbox mode)
- [x] All 54 existing MCQ tests still pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)