### PR TITLE
Remove dead process_submission() stubs from async handlers

### DIFF
--- a/purplex/problems_app/handlers/base.py
+++ b/purplex/problems_app/handlers/base.py
@@ -81,20 +81,21 @@ class ActivityHandler(ABC):
 
     # ─── Submission Processing ──────────────────────────────────
 
-    @abstractmethod
     def process_submission(
         self, submission: "Submission", raw_input: str, problem: "Problem"
     ) -> ProcessingResult:
         """
         Process the submission. This is the main type-specific logic.
 
-        For EiPL: Generate code variations, run tests, analyze segmentation
-        For Direct Code: Run tests on submitted code
-        For MCQ: Check selected answer
-
-        Should update submission fields and create any type-specific records.
+        Synchronous handlers (MCQ, Refute) override this to process inline.
+        Asynchronous handlers (EiPL, Prompt, DebugFix, ProbeableCode,
+        ProbeableSpec) inherit this default — their submit() queues a Celery
+        pipeline task instead.
         """
-        pass
+        raise NotImplementedError(
+            f"{self.type_name} handler does not support direct process_submission(). "
+            f"Async handlers delegate processing to Celery pipeline tasks via submit()."
+        )
 
     # ─── Grading ────────────────────────────────────────────────
 

--- a/purplex/problems_app/handlers/debug_fix/handler.py
+++ b/purplex/problems_app/handlers/debug_fix/handler.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 from .. import register_handler
 from ..base import (
     ActivityHandler,
-    ProcessingResult,
     SubmissionOutcome,
     ValidationResult,
 )
@@ -61,21 +60,6 @@ class DebugFixHandler(ActivityHandler):
             )
 
         return ValidationResult(is_valid=True)
-
-    # --- Submission Processing ---
-
-    def process_submission(
-        self, submission: "Submission", raw_input: str, problem: "Problem"
-    ) -> ProcessingResult:
-        """
-        Process Debug Fix submission.
-
-        Note: This is a stub. Actual processing is handled by the
-        execute_debug_fix_pipeline Celery task.
-        """
-        raise NotImplementedError(
-            "Debug Fix processing is handled by execute_debug_fix_pipeline task."
-        )
 
     # --- Grading ---
 

--- a/purplex/problems_app/handlers/eipl/handler.py
+++ b/purplex/problems_app/handlers/eipl/handler.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
 from ..base import (
     ActivityHandler,
-    ProcessingResult,
     SubmissionOutcome,
     ValidationResult,
 )
@@ -60,23 +59,6 @@ class EiPLHandler(ActivityHandler):
             )
 
         return ValidationResult(is_valid=True)
-
-    # ─── Submission Processing ──────────────────────────────────
-
-    def process_submission(
-        self, submission: "Submission", raw_input: str, problem: "Problem"
-    ) -> ProcessingResult:
-        """
-        Process EiPL submission.
-
-        Note: In Phase 1, this is a stub. Full implementation requires
-        pipeline integration (Phase 2+). Currently, processing is handled
-        by the execute_eipl_pipeline Celery task.
-        """
-        raise NotImplementedError(
-            "EiPL processing is handled by execute_eipl_pipeline task. "
-            "Direct handler processing will be available in Phase 2."
-        )
 
     # ─── Grading ────────────────────────────────────────────────
 

--- a/purplex/problems_app/handlers/probeable_code/handler.py
+++ b/purplex/problems_app/handlers/probeable_code/handler.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any
 from .. import register_handler
 from ..base import (
     ActivityHandler,
-    ProcessingResult,
     SubmissionOutcome,
     ValidationResult,
 )
@@ -90,21 +89,6 @@ class ProbeableCodeHandler(ActivityHandler):
             )
 
         return ValidationResult(is_valid=True)
-
-    # --- Submission Processing ---
-
-    def process_submission(
-        self, submission: "Submission", raw_input: str, problem: "Problem"
-    ) -> ProcessingResult:
-        """
-        Process Probeable Code submission.
-
-        Note: This is a stub. Actual processing is handled by the
-        execute_probeable_code_pipeline Celery task.
-        """
-        raise NotImplementedError(
-            "Probeable Code processing is handled by execute_probeable_code_pipeline task."
-        )
 
     # --- Grading ---
 

--- a/purplex/problems_app/handlers/probeable_spec/handler.py
+++ b/purplex/problems_app/handlers/probeable_spec/handler.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any
 from .. import register_handler
 from ..base import (
     ActivityHandler,
-    ProcessingResult,
     SubmissionOutcome,
     ValidationResult,
 )
@@ -87,22 +86,6 @@ class ProbeableSpecHandler(ActivityHandler):
             )
 
         return ValidationResult(is_valid=True)
-
-    # --- Submission Processing ---
-
-    def process_submission(
-        self, submission: "Submission", raw_input: str, problem: "Problem"
-    ) -> ProcessingResult:
-        """
-        Process Probeable Spec submission.
-
-        Note: Processing is handled by the execute_eipl_pipeline Celery task.
-        The pipeline is identical to EiPL - NL -> LLM code generation -> testing.
-        """
-        raise NotImplementedError(
-            "Probeable Spec processing is handled by execute_eipl_pipeline task. "
-            "Direct handler processing not supported."
-        )
 
     # --- Grading (reuses EiPL logic) ---
 

--- a/purplex/problems_app/handlers/prompt/handler.py
+++ b/purplex/problems_app/handlers/prompt/handler.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 
 from ..base import (
     ActivityHandler,
-    ProcessingResult,
     SubmissionOutcome,
     ValidationResult,
 )
@@ -57,21 +56,6 @@ class PromptHandler(ActivityHandler):
             )
 
         return ValidationResult(is_valid=True)
-
-    # --- Submission Processing ---
-
-    def process_submission(
-        self, submission: "Submission", raw_input: str, problem: "Problem"
-    ) -> ProcessingResult:
-        """
-        Process prompt submission.
-
-        Note: Processing is handled by the execute_eipl_pipeline Celery task.
-        """
-        raise NotImplementedError(
-            "Prompt processing is handled by execute_eipl_pipeline task. "
-            "Direct handler processing not supported."
-        )
 
     # --- Grading (delegates to EiPL logic) ---
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -14,7 +14,7 @@ from purplex.problems_app.handlers import (
     get_registered_types,
     is_registered,
 )
-from purplex.problems_app.handlers.base import ActivityHandler
+from purplex.problems_app.handlers.base import ActivityHandler, ProcessingResult
 
 # Mark all tests in this module as unit tests
 pytestmark = pytest.mark.unit
@@ -1307,3 +1307,95 @@ class TestPromptConfig:
 
         assert "image_url" in config["required_fields"]
         assert config["type_specific_section"] == "prompt_image"
+
+
+# ─── process_submission() contract tests ─────────────────────
+
+
+ASYNC_HANDLER_TYPES = [
+    "eipl",
+    "prompt",
+    "debug_fix",
+    "probeable_code",
+    "probeable_spec",
+]
+SYNC_HANDLER_TYPES = ["mcq", "refute"]
+
+
+class TestAsyncHandlersProcessSubmission:
+    """Async handlers should inherit the base class default for process_submission()."""
+
+    @pytest.fixture(params=ASYNC_HANDLER_TYPES)
+    def handler(self, request):
+        return get_handler(request.param)
+
+    def test_raises_not_implemented_error(self, handler):
+        """Calling process_submission() on an async handler should raise NotImplementedError."""
+        mock_submission = MagicMock()
+        mock_problem = MagicMock()
+
+        with pytest.raises(NotImplementedError) as exc_info:
+            handler.process_submission(mock_submission, "input", mock_problem)
+
+        assert handler.type_name in str(exc_info.value)
+        assert "Celery pipeline" in str(exc_info.value)
+
+    def test_inherits_from_base_class(self, handler):
+        """Async handlers should not override process_submission() — they inherit the base default."""
+        assert "process_submission" not in type(handler).__dict__
+
+    def test_error_message_includes_handler_type(self, handler):
+        """Error message should identify which handler was called."""
+        mock_submission = MagicMock()
+        mock_problem = MagicMock()
+
+        with pytest.raises(NotImplementedError, match=handler.type_name):
+            handler.process_submission(mock_submission, "input", mock_problem)
+
+
+class TestSyncHandlersProcessSubmission:
+    """Sync handlers should have their own working process_submission()."""
+
+    def test_mcq_has_own_process_submission(self):
+        """MCQ handler should override process_submission()."""
+        handler = get_handler("mcq")
+        assert "process_submission" in type(handler).__dict__
+
+    def test_refute_has_own_process_submission(self):
+        """Refute handler should override process_submission()."""
+        handler = get_handler("refute")
+        assert "process_submission" in type(handler).__dict__
+
+    def test_mcq_process_submission_returns_result(self):
+        """MCQ handler's process_submission should return a ProcessingResult."""
+        handler = get_handler("mcq")
+        mock_submission = MagicMock()
+        mock_problem = MagicMock()
+        mock_problem.slug = "test-mcq"
+        mock_problem.options = [
+            {"id": "1", "text": "Option A", "is_correct": True},
+            {"id": "2", "text": "Option B", "is_correct": False},
+        ]
+        mock_problem.allow_multiple = False
+
+        result = handler.process_submission(mock_submission, "1", mock_problem)
+
+        assert isinstance(result, ProcessingResult)
+        assert result.success is True
+        assert result.type_specific_data["is_correct"] is True
+
+
+class TestBaseClassProcessSubmission:
+    """Base class process_submission() default behavior."""
+
+    def test_base_default_is_not_abstract(self):
+        """process_submission should be a concrete method, not abstract."""
+        import inspect
+
+        method = ActivityHandler.process_submission
+        assert not getattr(method, "__isabstractmethod__", False)
+        # Should be a regular function, not decorated with @abstractmethod
+        assert callable(method)
+        # Verify it has a real implementation (not just `pass`)
+        source = inspect.getsource(method)
+        assert "NotImplementedError" in source


### PR DESCRIPTION
## Summary
- Moved `process_submission()` from `@abstractmethod` to a concrete default in `ActivityHandler` that raises `NotImplementedError` with a descriptive message
- Deleted the 5 redundant stubs from eipl, prompt, debug_fix, probeable_code, and probeable_spec handlers (plus unused `ProcessingResult` imports)
- Added 19 parametrized tests verifying async handlers inherit the base default and sync handlers still work

Closes #44

## Test plan
- [x] 127/128 handler tests pass (1 pre-existing failure in MCQ option ordering from shuffle PR)
- [x] All 19 new tests pass across all 5 async handler types + 2 sync handlers + base class

🤖 Generated with [Claude Code](https://claude.com/claude-code)