### PR TITLE
Fix prompt save test: expect top-level fields

### DIFF
--- a/purplex/client/src/composables/admin/__tests__/problemTypeHandlers.test.ts
+++ b/purplex/client/src/composables/admin/__tests__/problemTypeHandlers.test.ts
@@ -159,8 +159,8 @@ describe('problemTypeHandlers', () => {
 
       const saved = problemTypeHandlers.prompt.save(composables)
 
-      expect((saved.prompt_config as {image_url: string}).image_url).toBe('https://new-url.com/img.jpg')
-      expect((saved.prompt_config as {image_alt_text: string}).image_alt_text).toBe('New alt text')
+      expect(saved.image_url).toBe('https://new-url.com/img.jpg')
+      expect(saved.image_alt_text).toBe('New alt text')
     })
   })
 


### PR DESCRIPTION
Fixes #64. The test asserted saved.prompt_config.image_url but save() spreads fields at top level. Fixed to expect saved.image_url directly.