### PR TITLE
Fix useTheme localStorage TypeError in tests

### DIFF
--- a/purplex/client/src/composables/useTheme.ts
+++ b/purplex/client/src/composables/useTheme.ts
@@ -6,9 +6,13 @@ export type EffectiveTheme = 'light' | 'dark'
 const STORAGE_KEY = 'purplex_theme'
 
 function getStoredPreference(): ThemePreference {
-  const stored = localStorage.getItem(STORAGE_KEY)
-  if (stored === 'light' || stored === 'dark' || stored === 'auto') {
-    return stored
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'light' || stored === 'dark' || stored === 'auto') {
+      return stored
+    }
+  } catch {
+    // localStorage may be unavailable in test environments or restricted browsers
   }
   return 'auto'
 }


### PR DESCRIPTION
## Summary
- Wrap `localStorage.getItem()` in `getStoredPreference()` with try/catch, falling back to `'auto'` if localStorage is unavailable or throws
- Fixes `CorrectnessModal.i18n.test.ts` which failed because `useTheme.ts` calls `getStoredPreference()` at module evaluation time (line 34), before test `beforeEach` hooks can stub `localStorage`
- Also protects against restricted browser environments where localStorage may be disabled

Closes #63

## Test plan
- [x] `npx vitest run src/modals/__tests__/CorrectnessModal.i18n.test.ts` -- all 7 tests pass
- [x] `npx vitest run` -- 402/403 tests pass (1 pre-existing failure in `problemTypeHandlers.test.ts` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)