### PR TITLE
Fix test regressions from ESLint cleanup

### DIFF
--- a/purplex/client/src/components/instructor/__tests__/CourseTeamManager.test.ts
+++ b/purplex/client/src/components/instructor/__tests__/CourseTeamManager.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
+import { AxiosError } from 'axios'
 import CourseTeamManager from '../CourseTeamManager.vue'
 import type { CourseInstructorMember } from '@/types'
 
@@ -159,9 +160,15 @@ describe('CourseTeamManager', () => {
   })
 
   it('displays last-primary error gracefully', async () => {
-    mockRemoveCourseTeamMember.mockRejectedValue({
-      response: { data: { error: 'Cannot remove the last primary instructor from a course' } },
-    })
+    mockRemoveCourseTeamMember.mockRejectedValue(
+      new AxiosError(
+        'Request failed',
+        'ERR_BAD_REQUEST',
+        undefined,
+        undefined,
+        { status: 400, data: { error: 'Cannot remove the last primary instructor from a course' } } as never
+      )
+    )
     vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     const wrapper = mountComponent('primary')

--- a/purplex/client/src/services/__tests__/submissionService.test.ts
+++ b/purplex/client/src/services/__tests__/submissionService.test.ts
@@ -54,7 +54,7 @@ describe('SubmissionService', () => {
       await expect(submissionService.submitActivity({
         problem_slug: 'two-sum',
         raw_input: 'invalid'
-      })).rejects.toEqual({
+      })).rejects.toMatchObject({
         error: 'Validation error',
         status: 400
       })

--- a/purplex/client/src/services/submissionService.ts
+++ b/purplex/client/src/services/submissionService.ts
@@ -5,6 +5,18 @@ import type { BaseSubmission, CodeVariation, SubmissionDetailed, SubmissionHisto
 // Re-export submission types for convenience
 export type { BaseSubmission, SubmissionDetailed, CodeVariation, SubmissionTestResult };
 
+export class ServiceError extends Error {
+  error: string;
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ServiceError';
+    this.error = message;
+    this.status = status;
+  }
+}
+
 // ===== SUBMISSION TYPES =====
 
 /**
@@ -109,10 +121,10 @@ class SubmissionService {
     } catch (error: unknown) {
       log.error('Failed to submit activity solution', error);
       const axiosError = error as { response?: { data?: { error?: string }; status?: number } };
-      const err = new Error(axiosError.response?.data?.error || 'Failed to submit activity solution');
-      (err as Error & { error: string; status: number }).error = axiosError.response?.data?.error || 'Failed to submit activity solution';
-      (err as Error & { error: string; status: number }).status = axiosError.response?.status || 500;
-      throw err;
+      throw new ServiceError(
+        axiosError.response?.data?.error || 'Failed to submit activity solution',
+        axiosError.response?.status || 500
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- **submissionService**: Replace stapled Error properties with `ServiceError` class extending Error (same pattern as `AuthError`). Update test assertion from `toEqual` to `toMatchObject`.
- **CourseTeamManager**: Mock errors with real `AxiosError` instances so `axios.isAxiosError()` returns true in catch blocks.

## Test plan
- [x] `yarn test --run submissionService.test.ts` — 5 passed
- [x] `yarn test --run CourseTeamManager.test.ts` — 8 passed

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)