### PR TITLE
Fix E2E CI: stop gitignoring e2e/ and playwright.config.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,9 +196,9 @@ i18n-coverage.json
 
 # Development artifacts (screenshots, research, e2e)
 /*.png
-e2e/
+e2e/results/
+e2e/screenshots/
 papers/
-playwright.config.ts
 docs/lessons/*.pdf
 docs/lessons/*.mjs
 docs/research/

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,71 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Shape matches the User interface in auth.module.ts (line 83).
+ * The auth module reads localStorage.getItem('user') on load (line 147)
+ * and hydrates the Vuex store with { loggedIn: true, user }.
+ *
+ * In dev mode, DEBUG=true (line 77) bypasses route guards entirely,
+ * but injecting a proper user ensures components that read the user
+ * object render role-appropriate UI (admin panels, instructor tools, etc.).
+ */
+interface MockUser {
+  uid: string;
+  email: string;
+  displayName: string;
+  role: 'admin' | 'user' | 'instructor';
+  isAdmin: boolean;
+}
+
+const USERS: Record<string, MockUser> = {
+  student: {
+    uid: 'e2e-student-001',
+    email: 'student@test.local',
+    displayName: 'Test Student',
+    role: 'user',
+    isAdmin: false,
+  },
+  instructor: {
+    uid: 'e2e-instructor-001',
+    email: 'instructor@test.local',
+    displayName: 'Test Instructor',
+    role: 'instructor',
+    isAdmin: false,
+  },
+  admin: {
+    uid: 'e2e-admin-001',
+    email: 'admin@test.local',
+    displayName: 'Test Admin',
+    role: 'admin',
+    isAdmin: true,
+  },
+};
+
+/**
+ * Inject a mock user into localStorage so the Vue app boots as authenticated.
+ *
+ * Must be called before navigating to the target route — the auth module
+ * reads localStorage synchronously during Vuex store initialization.
+ *
+ * Navigates to the baseURL first to establish the origin (localStorage is
+ * origin-scoped), then sets the values via page.evaluate().
+ */
+export async function injectAuth(
+  page: Page,
+  role: 'student' | 'instructor' | 'admin',
+): Promise<void> {
+  const user = USERS[role];
+
+  // Must be on the same origin before we can write to localStorage.
+  // Use a bare GET to the root — the page will redirect, but that's fine;
+  // we only need the origin established.
+  await page.goto('/', { waitUntil: 'commit' });
+
+  await page.evaluate(
+    ({ userJson, consent }) => {
+      localStorage.setItem('user', userJson);
+      localStorage.setItem('purplex_cookie_consent', consent);
+    },
+    { userJson: JSON.stringify(user), consent: 'accepted' },
+  );
+}

--- a/e2e/helpers/theme.ts
+++ b/e2e/helpers/theme.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Set the theme preference in localStorage before navigation.
+ *
+ * The FOUC script in index.html (line 13-19) reads `purplex_theme`
+ * synchronously before the Vue app mounts and sets `data-theme` on <html>.
+ * The useTheme composable (useTheme.ts:8) also reads this key on init.
+ *
+ * Call this AFTER injectAuth (which navigates to establish the origin)
+ * but BEFORE navigating to the target route.
+ */
+export async function setTheme(
+  page: Page,
+  theme: 'light' | 'dark',
+): Promise<void> {
+  await page.evaluate(
+    (t) => { localStorage.setItem('purplex_theme', t); },
+    theme,
+  );
+}

--- a/e2e/visual-theme-audit.spec.ts
+++ b/e2e/visual-theme-audit.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from '@playwright/test';
+import { injectAuth } from './helpers/auth';
+import { setTheme } from './helpers/theme';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Route definitions — every static route in router.ts, grouped by auth level
+// ---------------------------------------------------------------------------
+
+type AuthRole = 'student' | 'instructor' | 'admin' | null;
+
+interface RouteEntry {
+  path: string;
+  auth: AuthRole;
+}
+
+const ROUTES: Record<string, RouteEntry> = {
+  // Public (no auth required)
+  'login':              { path: '/', auth: null },
+  'privacy':            { path: '/privacy', auth: 'student' },
+  'terms':              { path: '/terms', auth: 'student' },
+
+  // Student (requiresAuth)
+  'home':               { path: '/home', auth: 'student' },
+  'privacy-settings':   { path: '/settings/privacy', auth: 'student' },
+
+  // Instructor
+  'instructor-dashboard':    { path: '/instructor', auth: 'instructor' },
+  'instructor-courses':      { path: '/instructor/courses', auth: 'instructor' },
+  'instructor-course-new':   { path: '/instructor/courses/new', auth: 'instructor' },
+  'instructor-problems':     { path: '/instructor/problems', auth: 'instructor' },
+  'instructor-problem-new':  { path: '/instructor/problems/new', auth: 'instructor' },
+  'instructor-problem-sets': { path: '/instructor/problem-sets', auth: 'instructor' },
+  'instructor-ps-new':       { path: '/instructor/problem-sets/new', auth: 'instructor' },
+
+  // Admin
+  'admin-users':        { path: '/admin/users', auth: 'admin' },
+  'admin-problems':     { path: '/admin/problems', auth: 'admin' },
+  'admin-problem-sets': { path: '/admin/problem-sets', auth: 'admin' },
+  'admin-submissions':  { path: '/admin/submissions', auth: 'admin' },
+  'admin-courses':      { path: '/admin/courses', auth: 'admin' },
+  'admin-course-new':   { path: '/admin/courses/new', auth: 'admin' },
+};
+
+// Data-dependent routes — uncomment after seeding the dev database.
+// These require the backend to be running with test data loaded.
+//
+// 'course-detail':              { path: '/courses/ENGGEN131', auth: 'student' },
+// 'course-problem-set':         { path: '/courses/ENGGEN131/problem-set/demo-problem-set', auth: 'student' },
+// 'instructor-course-overview': { path: '/instructor/courses/ENGGEN131', auth: 'instructor' },
+// 'instructor-course-students': { path: '/instructor/courses/ENGGEN131/students', auth: 'instructor' },
+// 'instructor-course-subs':     { path: '/instructor/courses/ENGGEN131/submissions', auth: 'instructor' },
+// 'instructor-course-ps':       { path: '/instructor/courses/ENGGEN131/problem-sets', auth: 'instructor' },
+// 'admin-course-students':      { path: '/admin/courses/ENGGEN131/students', auth: 'admin' },
+// 'admin-course-ps':            { path: '/admin/courses/ENGGEN131/problem-sets', auth: 'admin' },
+
+const THEMES = ['dark', 'light'] as const;
+const SCREENSHOT_ROOT = path.resolve(__dirname, '..', 'visual-tests', 'screenshots');
+
+// ---------------------------------------------------------------------------
+// Main audit: screenshot every route × every theme
+// ---------------------------------------------------------------------------
+
+for (const theme of THEMES) {
+  test.describe(`Theme: ${theme}`, () => {
+    for (const [name, route] of Object.entries(ROUTES)) {
+      test(`${name} (${route.path})`, async ({ page }) => {
+        // Ensure output directory exists
+        const dir = path.join(SCREENSHOT_ROOT, theme);
+        fs.mkdirSync(dir, { recursive: true });
+
+        // 1. Inject auth (if needed) — this navigates to origin first
+        if (route.auth) {
+          await injectAuth(page, route.auth);
+        } else {
+          // Still need to establish origin for theme localStorage
+          await page.goto('/', { waitUntil: 'commit' });
+          // Dismiss cookie banner for clean screenshots
+          await page.evaluate(() => {
+            localStorage.setItem('purplex_cookie_consent', 'accepted');
+          });
+        }
+
+        // 2. Set theme
+        await setTheme(page, theme);
+
+        // 3. Navigate to the target route
+        await page.goto(route.path, {
+          waitUntil: 'networkidle',
+          timeout: 15_000,
+        });
+
+        // 4. Let animations and transitions settle
+        await page.waitForTimeout(500);
+
+        // 5. Take full-page screenshot
+        const screenshotPath = path.join(dir, `${name}.png`);
+        await page.screenshot({ path: screenshotPath, fullPage: true });
+
+        // Sanity check: file was actually written
+        expect(fs.existsSync(screenshotPath)).toBe(true);
+      });
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Special cases
+// ---------------------------------------------------------------------------
+
+test.describe('Special cases', () => {
+  for (const theme of THEMES) {
+    test(`cookie-consent-banner — ${theme}`, async ({ page }) => {
+      const dir = path.join(SCREENSHOT_ROOT, theme);
+      fs.mkdirSync(dir, { recursive: true });
+
+      await page.goto('/', { waitUntil: 'commit' });
+
+      // Explicitly remove cookie consent so the banner is visible
+      await page.evaluate(() => {
+        localStorage.removeItem('purplex_cookie_consent');
+        localStorage.setItem('purplex_theme', 'placeholder');
+      });
+      await setTheme(page, theme);
+
+      await page.goto('/', { waitUntil: 'networkidle', timeout: 15_000 });
+      await page.waitForTimeout(500);
+
+      await page.screenshot({
+        path: path.join(dir, 'cookie-consent-banner.png'),
+        fullPage: true,
+      });
+    });
+
+    test(`account-modal — ${theme}`, async ({ page }) => {
+      const dir = path.join(SCREENSHOT_ROOT, theme);
+      fs.mkdirSync(dir, { recursive: true });
+
+      await injectAuth(page, 'student');
+      await setTheme(page, theme);
+
+      await page.goto('/home', {
+        waitUntil: 'networkidle',
+        timeout: 15_000,
+      });
+      await page.waitForTimeout(500);
+
+      // Open the account modal via the nav bar button
+      const accountBtn = page.locator('button.account-item');
+      await accountBtn.click();
+      await page.waitForSelector('#account-modal-title', { timeout: 3_000 });
+      await page.waitForTimeout(300);
+
+      await page.screenshot({
+        path: path.join(dir, 'account-modal.png'),
+        fullPage: true,
+      });
+    });
+  }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './visual-tests/screenshots',
+
+  // No parallel — sequential is fine for a screenshot walkthrough
+  fullyParallel: false,
+  workers: 1,
+
+  // No retries — if a page fails to load, we want to know immediately
+  retries: 0,
+
+  // HTML reporter for side-by-side review
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'off',
+    screenshot: 'off', // we take manual screenshots
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+
+  // No webServer — start services manually via ./start.sh
+});


### PR DESCRIPTION
## Summary
The e2e.yml workflow failed with "No tests found" because `e2e/` was in `.gitignore`. Now only generated output (`e2e/results/`, `e2e/screenshots/`) is ignored. Also tracks `playwright.config.ts`.

## Test plan
- [ ] E2E workflow finds and runs smoke tests on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)