### PR TITLE
Enable CD on master push for single-VM production deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,7 @@ name: Continuous Deployment
 on:
   push:
     tags: [ 'v*' ]
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       environment:
@@ -110,8 +111,8 @@ jobs:
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    needs: [build-and-push, deploy-staging]
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.environment == 'production'
+    needs: [build-and-push]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.environment == 'production' || github.ref == 'refs/heads/master'
     environment:
       name: production
       url: https://purplex.com
@@ -140,8 +141,9 @@ jobs:
         run: |
           ssh -i deploy_key -o StrictHostKeyChecking=no $PROD_USER@$PROD_HOST << EOF
             cd /opt/purplex
-            git fetch --tags
-            git checkout $VERSION
+            git fetch origin master --tags
+            git checkout master
+            git pull origin master
             docker-compose -f config/docker/production.yml pull
             docker-compose -f config/docker/production.yml down
             docker-compose -f config/docker/production.yml up -d


### PR DESCRIPTION
## Summary
- Trigger CD workflow on master branch pushes (not just `v*` tags)
- Remove staging dependency — single-VM setup deploys directly to production
- Update production deploy step to `git pull origin master` instead of tag checkout

## Context
Sets up automatic deployment to the production VM when code is merged to master. The GitHub Environment protection rule on `production` provides an approval gate before the deploy executes.

## Test plan
- [ ] Merge this PR to master
- [ ] Verify the CD workflow triggers in the Actions tab
- [ ] Approve the production deployment in the Actions UI
- [ ] Verify the VM pulls and restarts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)