### PR TITLE
Remove nonexistent clear_cache command from CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,7 +89,6 @@ jobs:
           docker compose -f config/docker/production.yml up -d
           docker compose -f config/docker/production.yml exec -T app python manage.py migrate
           docker compose -f config/docker/production.yml exec -T app python manage.py collectstatic --noinput
-          docker compose -f config/docker/production.yml exec -T app python manage.py clear_cache
 
       - name: Run smoke tests
         run: |


### PR DESCRIPTION
This command doesn't exist — was failing the deploy.