### PR TITLE
Add path filters to reduce workflow noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: Continuous Integration
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'purplex/**'
+      - 'tests/**'
+      - 'requirements.txt'
+      - 'Dockerfile*'
+      - 'pyproject.toml'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,13 @@ name: E2E Tests
 on:
   push:
     branches: [master]
+    paths:
+      - 'purplex/**'
+      - 'tests/**'
+      - 'e2e/**'
+      - 'requirements.txt'
+      - 'playwright.config.ts'
+      - '.github/workflows/e2e.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -3,8 +3,18 @@ name: PostgreSQL Tests
 on:
   push:
     branches: [master]
+    paths:
+      - 'purplex/**/*.py'
+      - 'tests/**'
+      - 'requirements.txt'
+      - '.github/workflows/postgres-tests.yml'
   pull_request:
     branches: [master]
+    paths:
+      - 'purplex/**/*.py'
+      - 'tests/**'
+      - 'requirements.txt'
+      - '.github/workflows/postgres-tests.yml'
 
 jobs:
   test-postgres:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,14 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
+    paths:
+      - 'requirements.txt'
+      - 'purplex/**/*.py'
+      - 'purplex/client/package.json'
+      - 'purplex/client/yarn.lock'
+      - 'Dockerfile*'
+      - '.trivyignore'
+      - '.github/workflows/security.yml'
   pull_request:
     branches: [master]
     paths:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,21 +158,21 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 90
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "dab4fb93ec0b6fab34ac303369fa5d25cd186a49",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 136
       }
     ],
     ".github/workflows/postgres-load-tests.yml": [
@@ -204,35 +204,35 @@
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 28
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 70
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "b71d494da8d930401ba9b32b7cef87295f3eb6d3",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 72
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "96ef8965818820135c497997663cd2327844b969",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 122
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 190
+        "line_number": 200
       }
     ],
     "deploy/scripts/deploy_to_aws.sh": [
@@ -360,5 +360,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-30T03:53:23Z"
+  "generated_at": "2026-04-04T03:33:16Z"
 }


### PR DESCRIPTION
## Summary
- CI: only runs on push when code, tests, deps, or Dockerfile change
- PostgreSQL tests: only runs on Python/test/requirements changes (skips frontend-only)
- E2E: only runs when app code, e2e tests, or playwright config change
- Security: only runs on push when deps, Python code, or Dockerfiles change (scheduled scan unchanged)
- CD: unchanged — always deploys on master push

This means a workflow-config-only change (like editing cd.yml) will only trigger CD, not all 5 workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)