### PR TITLE
Fix E2E CI: install root deps for @playwright/test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,6 +93,9 @@ jobs:
         working-directory: purplex/client
         run: yarn install --frozen-lockfile
 
+      - name: Install Playwright dependencies
+        run: npm ci
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 


### PR DESCRIPTION
Missing npm ci at root level.