### PR TITLE
Add path filter to CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,12 @@ on:
   push:
     tags: [ 'v*' ]
     branches: [ master ]
+    paths:
+      - 'purplex/**'
+      - 'requirements.txt'
+      - 'Dockerfile*'
+      - 'config/docker/**'
+      - '.github/workflows/cd.yml'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Test/workflow/doc changes no longer trigger a deployment.