### PR TITLE
Exclude test files from CD path filter

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,9 @@ on:
     branches: [ master ]
     paths:
       - 'purplex/**'
+      - '!purplex/**/__tests__/**'
+      - '!purplex/**/*.test.ts'
+      - '!purplex/**/*.spec.ts'
       - 'requirements.txt'
       - 'Dockerfile*'
       - 'config/docker/**'


### PR DESCRIPTION
Prevents deploys on test-only changes.