### PR TITLE
Add deploy safety, fix E2E startup, add permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,9 @@
 name: Continuous Deployment
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: cd-production
   cancel-in-progress: false
@@ -93,6 +97,21 @@ jobs:
       name: production
       url: https://purplex.org
     steps:
+      - name: Verify CI passed
+        run: |
+          RESULT=$(gh run list --workflow=ci.yml --branch=master --limit=1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
+          if [ "$RESULT" != "success" ]; then
+            echo "CI has not passed on master (status: $RESULT). Aborting deploy."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Record current version
+        run: |
+          cd /opt/purplex
+          git rev-parse HEAD > /tmp/pre-deploy-sha
+
       - name: Create database backup
         run: |
           cd /opt/purplex
@@ -112,8 +131,19 @@ jobs:
 
       - name: Run smoke tests
         run: |
-          sleep 30
-          curl -f https://purplex.org/health/ || exit 1
+          for i in $(seq 1 30); do curl -sf https://purplex.org/health/ && exit 0 || sleep 2; done
+          echo "Smoke test failed after 60s"
+          exit 1
+
+      - name: Rollback on failure
+        if: failure()
+        run: |
+          if [ -f /tmp/pre-deploy-sha ]; then
+            echo "Rolling back to $(cat /tmp/pre-deploy-sha)"
+            cd /opt/purplex
+            git checkout $(cat /tmp/pre-deploy-sha)
+            docker compose -f config/docker/production.yml up -d
+          fi
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,8 @@
 name: E2E Tests
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -108,13 +111,13 @@ jobs:
       - name: Start Django server
         run: |
           python manage.py runserver 0.0.0.0:8000 &
-          sleep 3
+          for i in $(seq 1 30); do curl -sf http://localhost:8000/api/health/ && break || sleep 1; done
 
       - name: Start Vite dev server
         working-directory: purplex/client
         run: |
           yarn dev --host &
-          sleep 5
+          for i in $(seq 1 30); do curl -sf http://localhost:5173/ && break || sleep 1; done
 
       - name: Run E2E tests
         run: npx playwright test --reporter=list

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -1,5 +1,8 @@
 name: PostgreSQL Tests
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,21 +158,21 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 97
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 141
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "dab4fb93ec0b6fab34ac303369fa5d25cd186a49",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 143
       }
     ],
     ".github/workflows/postgres-load-tests.yml": [
@@ -204,35 +204,35 @@
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 35
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 77
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "b71d494da8d930401ba9b32b7cef87295f3eb6d3",
         "is_verified": false,
-        "line_number": 76
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "96ef8965818820135c497997663cd2327844b969",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/postgres-tests.yml",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 207
       }
     ],
     "deploy/scripts/deploy_to_aws.sh": [
@@ -360,5 +360,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-04T03:37:45Z"
+  "generated_at": "2026-04-04T15:08:05Z"
 }


### PR DESCRIPTION
## Summary
- CD verifies CI passed on master before deploying
- CD records pre-deploy SHA and auto-rolls back on failure
- CD smoke test uses retry loop instead of blind `sleep 30`
- E2E replaces fragile `sleep` with health-check polling for server startup
- All workflows get explicit least-privilege `permissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)