### PR TITLE
Track root package.json for E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,8 @@ playwright-report/
 test-results/
 blob-report/
 
-# Root package.json (not part of the build system)
-/package.json
+# Root package.json — tracked for E2E Playwright deps
+# /package.json
 
 # Development artifacts
 verify_architecture.py

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "playwright": "^1.57.0",
+    "puppeteer": "^24.32.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
+  }
+}


### PR DESCRIPTION
Was gitignored — E2E CI needs it for @playwright/test.