### PR TITLE
Store Celery eager results for SSE compatibility

### DIFF
--- a/purplex/settings/development.py
+++ b/purplex/settings/development.py
@@ -117,6 +117,7 @@ X_FRAME_OPTIONS = "SAMEORIGIN"
 # Celery development settings
 CELERY_TASK_ALWAYS_EAGER = os.environ.get("CELERY_EAGER", "false").lower() == "true"
 CELERY_TASK_EAGER_PROPAGATES = True
+CELERY_TASK_STORE_EAGER_RESULT = True
 
 # Cache configuration for development (use local memory)
 CACHES = {


### PR DESCRIPTION
## Summary
- Adds `CELERY_TASK_STORE_EAGER_RESULT = True` to development settings
- Fixes the remaining 4 student E2E test timeouts from #114

**Root cause**: Celery 5.x defaults `task_store_eager_result` to `False`. In eager mode, the task runs synchronously during `apply_async()` and completes before the 202 response is sent. The SSE endpoint then creates a new `AsyncResult(task_id)` and queries Redis — but finds nothing because the eager result was only held in memory. The frontend waits forever for `.generating-feedback-panel` to hide.

## Test plan
- [ ] Student E2E job passes (hints.spec.ts + submission-eipl.spec.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)