### PR TITLE
Add unique constraint on auth_user.email

### DIFF
--- a/purplex/users_app/migrations/0006_enforce_unique_email.py
+++ b/purplex/users_app/migrations/0006_enforce_unique_email.py
@@ -1,0 +1,23 @@
+"""
+Add a unique constraint on auth_user.email to prevent duplicate accounts.
+
+Django's default User model does not enforce email uniqueness at the DB level.
+This caused a MultipleObjectsReturned crash when looking up users by email
+(e.g., adding an instructor to a course).
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users_app", "0005_userconsent_immutability_trigger"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql='ALTER TABLE auth_user ADD CONSTRAINT auth_user_email_unique UNIQUE (email);',
+            reverse_sql='ALTER TABLE auth_user DROP CONSTRAINT auth_user_email_unique;',
+        ),
+    ]

--- a/purplex/users_app/repositories/user_repository.py
+++ b/purplex/users_app/repositories/user_repository.py
@@ -76,6 +76,15 @@ class UserRepository(BaseRepository):
             return User.objects.select_related("profile").get(email__iexact=email)
         except User.DoesNotExist:
             return None
+        except User.MultipleObjectsReturned:
+            # DB unique constraint should prevent this, but handle defensively.
+            # Return the most recently active account.
+            return (
+                User.objects.select_related("profile")
+                .filter(email__iexact=email)
+                .order_by("-last_login", "-date_joined")
+                .first()
+            )
 
     @classmethod
     def get_service_account(cls) -> User | None:


### PR DESCRIPTION
## Summary
- Adds a DB-level `UNIQUE` constraint on `auth_user.email` via migration to prevent duplicate accounts
- Hardens `UserRepository.get_by_email()` to handle `MultipleObjectsReturned` defensively
- Duplicate account (id=14, username `jcd`) already deleted from prod and constraint already applied to prod DB

## Context
Megha hit a 500 error trying to add an instructor to CS252. The email she entered had 2 matching User rows, causing `get()` to crash. See #118 for full details.

## Test plan
- [ ] Verify `get_by_email` returns a user when exactly one match exists
- [ ] Verify `get_by_email` returns `None` when no match exists
- [ ] Verify DB rejects `INSERT` of duplicate email
- [ ] Verify migration applies cleanly on fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)