### PR TITLE
Prompt for AI consent in-app instead of dead-ending submissions

### DIFF
--- a/e2e/student/ai-consent-modal.spec.ts
+++ b/e2e/student/ai-consent-modal.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * E2E Tests: AI Consent Modal Flow (issue #121)
+ *
+ * Covers the in-app grant experience for users without AI processing consent.
+ *
+ * Flow:
+ *   1. Test starts by withdrawing student's AI_PROCESSING consent via API.
+ *   2. Student attempts an EiPL submission.
+ *   3. The backend returns 403 + code=consent_required + purpose=ai_processing.
+ *   4. The axios interceptor routes to the AIConsentModal.
+ *   5. Clicking "Enable AI features" calls POST /api/users/me/consents/ with
+ *      consent_method=in_app, then retries the original submission.
+ *   6. Clicking "Not now" rejects the submission cleanly.
+ *
+ * Prerequisites (same as submission-eipl.spec.ts):
+ *   1. Django dev server on :8000 with USE_MOCK_FIREBASE=true
+ *   2. Celery worker
+ *   3. Vite dev server on :5173
+ *   4. python manage.py create_test_users && python manage.py seed_e2e_data
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import { navigateAs } from '../helpers/navigation';
+import { apiAs } from '../helpers/api';
+
+const EIPL_PATH = '/courses/CS101-2024/problem-set/e2e-basics?p=1';
+const VALID_EXPLANATION =
+  'This function adds up all the numbers in the input list and returns the total.';
+
+async function withdrawAIConsent(page: Page) {
+  await page.goto('/', { waitUntil: 'commit' });
+  await apiAs(page, 'student', 'DELETE', '/api/users/me/consents/ai_processing/');
+}
+
+async function ensureAIConsentGranted(page: Page) {
+  // Safety net: runs after each test so a failure mid-flow doesn't leave the
+  // student in a withdrawn-consent state that breaks later EiPL tests.
+  await page.goto('/', { waitUntil: 'commit' });
+  await apiAs(page, 'student', 'POST', '/api/users/me/consents/', {
+    consent_type: 'ai_processing',
+  });
+}
+
+async function typeInEditor(page: Page, text: string) {
+  const editorTextarea = page.locator('#promptEditor .ace_text-input').first();
+  await editorTextarea.focus();
+  await page.keyboard.press('Control+a');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.type(text, { delay: 10 });
+}
+
+test.describe('AI Consent Modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await withdrawAIConsent(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await ensureAIConsentGranted(page);
+  });
+
+  test('submitting without AI consent surfaces the grant modal', async ({ page }) => {
+    await navigateAs(page, 'student', EIPL_PATH);
+    await page
+      .locator('#promptEditor, .description-input, .prompt-editor-wrapper')
+      .first()
+      .waitFor({ state: 'visible', timeout: 15000 });
+
+    await typeInEditor(page, VALID_EXPLANATION);
+    await page.locator('#submitButton').click();
+
+    // The modal is a Teleport to body with role="alertdialog".
+    const modal = page.getByRole('alertdialog');
+    await expect(modal).toBeVisible({ timeout: 10000 });
+    await expect(modal).toContainText(/AI features/i);
+  });
+
+  test('granting from the modal retries the submission with audit=in_app', async ({ page }) => {
+    await navigateAs(page, 'student', EIPL_PATH);
+    await page
+      .locator('#promptEditor, .description-input, .prompt-editor-wrapper')
+      .first()
+      .waitFor({ state: 'visible', timeout: 15000 });
+
+    await typeInEditor(page, VALID_EXPLANATION);
+    await page.locator('#submitButton').click();
+
+    const modal = page.getByRole('alertdialog');
+    await expect(modal).toBeVisible({ timeout: 10000 });
+
+    // Track the POST to the consent endpoint and its payload so we can assert
+    // the modal tagged the audit record correctly.
+    const [consentPost] = await Promise.all([
+      page.waitForRequest(
+        (req) =>
+          req.url().includes('/api/users/me/consents/') && req.method() === 'POST',
+        { timeout: 10000 },
+      ),
+      modal.getByRole('button', { name: /Enable AI features/i }).click(),
+    ]);
+    const postedBody = consentPost.postDataJSON() as Record<string, unknown>;
+    expect(postedBody.consent_type).toBe('ai_processing');
+    expect(postedBody.consent_method).toBe('in_app');
+
+    // The modal closes after the grant completes.
+    await expect(modal).toBeHidden({ timeout: 10000 });
+
+    // The original submission is retried automatically — the submit button
+    // should go back to its loading/disabled state (proof the retry fired).
+    const submitBtn = page.locator('#submitButton');
+    await expect(submitBtn).toBeDisabled({ timeout: 5000 });
+  });
+
+  test('declining dismisses the modal and does not retry', async ({ page }) => {
+    await navigateAs(page, 'student', EIPL_PATH);
+    await page
+      .locator('#promptEditor, .description-input, .prompt-editor-wrapper')
+      .first()
+      .waitFor({ state: 'visible', timeout: 15000 });
+
+    await typeInEditor(page, VALID_EXPLANATION);
+    await page.locator('#submitButton').click();
+
+    const modal = page.getByRole('alertdialog');
+    await expect(modal).toBeVisible({ timeout: 10000 });
+    await modal.getByRole('button', { name: /Not now/i }).click();
+
+    await expect(modal).toBeHidden({ timeout: 5000 });
+
+    // After decline, the student should still lack AI consent.
+    const listRes = await apiAs(page, 'student', 'GET', '/api/users/me/consents/');
+    expect(listRes.data.ai_processing?.granted).toBeFalsy();
+  });
+});

--- a/purplex/client/src/App.vue
+++ b/purplex/client/src/App.vue
@@ -34,6 +34,7 @@
 
     <NotificationToast />
     <CookieConsent />
+    <AIConsentModal />
     <footer class="app-footer">
       <div class="footer-content">
         <div class="footer-left">
@@ -78,6 +79,7 @@ import Login from './features/auth/Login.vue';
 import NavBar from './components/NavBar.vue';
 import NotificationToast from './components/NotificationToast.vue';
 import CookieConsent from './components/privacy/CookieConsent.vue';
+import AIConsentModal from './components/privacy/AIConsentModal.vue';
 
 export default defineComponent({
     name: 'App',
@@ -85,7 +87,8 @@ export default defineComponent({
         Login,
         NavBar,
         NotificationToast,
-        CookieConsent
+        CookieConsent,
+        AIConsentModal
     },
     setup() {
         const store = useStore();

--- a/purplex/client/src/components/privacy/AIConsentModal.vue
+++ b/purplex/client/src/components/privacy/AIConsentModal.vue
@@ -81,7 +81,9 @@ async function onGrant() {
 }
 
 function onDecline() {
-  if (loading.value) return;
+  if (loading.value) {
+    return;
+  }
   errorMessage.value = null;
   store.dispatch('consentPrompt/resolveDecision', false);
 }

--- a/purplex/client/src/components/privacy/AIConsentModal.vue
+++ b/purplex/client/src/components/privacy/AIConsentModal.vue
@@ -1,0 +1,170 @@
+<template>
+  <Teleport to="body">
+    <Transition name="dialog-fade">
+      <div
+        v-if="visible"
+        class="dialog-overlay"
+        @click.self="onDecline"
+      >
+        <div
+          class="dialog"
+          role="alertdialog"
+          :aria-label="$t('auth.privacy.aiConsentPrompt.title')"
+        >
+          <h3>{{ $t('auth.privacy.aiConsentPrompt.title') }}</h3>
+          <p>{{ $t('auth.privacy.aiConsentPrompt.body') }}</p>
+          <p
+            v-if="errorMessage"
+            class="error"
+            role="alert"
+          >
+            {{ errorMessage }}
+          </p>
+          <div class="dialog-actions">
+            <button
+              class="btn btn-secondary"
+              :disabled="loading"
+              @click="onDecline"
+            >
+              {{ $t('auth.privacy.aiConsentPrompt.decline') }}
+            </button>
+            <button
+              class="btn btn-primary"
+              :disabled="loading"
+              @click="onGrant"
+            >
+              {{ loading ? $t('auth.privacy.aiConsentPrompt.granting') : $t('auth.privacy.aiConsentPrompt.grant') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useStore } from 'vuex';
+import privacyService from '../../services/privacyService';
+import { log } from '../../utils/logger';
+
+const store = useStore();
+const { t } = useI18n();
+
+const visible = computed<boolean>(() => store.state.consentPrompt.visible);
+const purpose = computed<string | null>(() => store.state.consentPrompt.purpose);
+
+const loading = ref(false);
+const errorMessage = ref<string | null>(null);
+
+async function onGrant() {
+  if (purpose.value !== 'ai_processing') {
+    // Future purposes will need their own grant calls — fail loudly if we're
+    // asked to handle one we don't understand instead of silently accepting.
+    log.error('AIConsentModal: unsupported purpose', purpose.value);
+    errorMessage.value = t('auth.privacy.aiConsentPrompt.error');
+    return;
+  }
+
+  loading.value = true;
+  errorMessage.value = null;
+  try {
+    await privacyService.grantConsent('ai_processing', { consent_method: 'in_app' });
+    store.dispatch('consentPrompt/resolveDecision', true);
+  } catch (err) {
+    log.error('AIConsentModal: grantConsent failed', err);
+    errorMessage.value = t('auth.privacy.aiConsentPrompt.error');
+  } finally {
+    loading.value = false;
+  }
+}
+
+function onDecline() {
+  if (loading.value) return;
+  errorMessage.value = null;
+  store.dispatch('consentPrompt/resolveDecision', false);
+}
+</script>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--color-backdrop);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dialog {
+  background: var(--color-bg-panel);
+  padding: var(--spacing-xl);
+  border-radius: var(--radius-lg);
+  max-width: 480px;
+  width: 90%;
+  box-shadow: var(--shadow-lg);
+}
+
+.dialog h3 {
+  margin: 0 0 var(--spacing-lg) 0;
+  color: var(--color-text-primary);
+}
+
+.dialog p {
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-lg);
+  line-height: 1.5;
+}
+
+.dialog p.error {
+  color: var(--color-error);
+}
+
+.dialog-actions {
+  display: flex;
+  gap: var(--spacing-md);
+  justify-content: flex-end;
+  margin-top: var(--spacing-lg);
+}
+
+.btn {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-base);
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: var(--transition-base);
+}
+
+.btn-secondary {
+  background: var(--color-bg-hover);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-bg-border);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-text-on-filled);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dialog-fade-enter-active,
+.dialog-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.dialog-fade-enter-from,
+.dialog-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/purplex/client/src/components/privacy/__tests__/AIConsentModal.test.ts
+++ b/purplex/client/src/components/privacy/__tests__/AIConsentModal.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import AIConsentModal from '../AIConsentModal.vue'
+import { consentPrompt } from '../../../store/consentPrompt.module'
+
+const grantConsentMock = vi.fn()
+
+vi.mock('../../../services/privacyService', () => ({
+  default: {
+    grantConsent: (...args: unknown[]) => grantConsentMock(...args),
+  },
+}))
+
+vi.mock('../../../utils/logger', () => ({
+  log: { info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+function mountModal() {
+  const store = createStore({ modules: { consentPrompt } })
+  const wrapper = mount(AIConsentModal, {
+    global: { plugins: [store], stubs: { Teleport: true, Transition: false } },
+  })
+  return { wrapper, store }
+}
+
+describe('AIConsentModal', () => {
+  beforeEach(() => {
+    grantConsentMock.mockReset()
+  })
+
+  it('is hidden when consent prompt is not visible', () => {
+    const { wrapper } = mountModal()
+    expect(wrapper.find('[role="alertdialog"]').exists()).toBe(false)
+  })
+
+  it('renders with grant and decline buttons when shown', async () => {
+    const { wrapper, store } = mountModal()
+    store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+    await flushPromises()
+
+    expect(wrapper.find('[role="alertdialog"]').exists()).toBe(true)
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toBe(2)
+  })
+
+  it('grants with consent_method=in_app then resolves the decision promise', async () => {
+    grantConsentMock.mockResolvedValue({ consent_type: 'ai_processing', granted: true })
+    const { wrapper, store } = mountModal()
+    const decision = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+    await flushPromises()
+
+    await wrapper.findAll('button')[1].trigger('click') // grant button
+    await flushPromises()
+
+    expect(grantConsentMock).toHaveBeenCalledWith('ai_processing', {
+      consent_method: 'in_app',
+    })
+    await expect(decision).resolves.toBe(true)
+    expect(store.state.consentPrompt.visible).toBe(false)
+  })
+
+  it('resolves decision with false when the user declines', async () => {
+    const { wrapper, store } = mountModal()
+    const decision = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+    await flushPromises()
+
+    await wrapper.findAll('button')[0].trigger('click') // decline button
+    await flushPromises()
+
+    expect(grantConsentMock).not.toHaveBeenCalled()
+    await expect(decision).resolves.toBe(false)
+    expect(store.state.consentPrompt.visible).toBe(false)
+  })
+
+  it('keeps modal open and shows inline error when grant fails', async () => {
+    grantConsentMock.mockRejectedValue(new Error('network'))
+    const { wrapper, store } = mountModal()
+    store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+    await flushPromises()
+
+    await wrapper.findAll('button')[1].trigger('click') // grant button
+    await flushPromises()
+
+    expect(store.state.consentPrompt.visible).toBe(true)
+    expect(wrapper.find('[role="alert"]').exists()).toBe(true)
+  })
+})

--- a/purplex/client/src/components/privacy/__tests__/AIConsentModal.test.ts
+++ b/purplex/client/src/components/privacy/__tests__/AIConsentModal.test.ts
@@ -27,6 +27,12 @@ function mountModal() {
 describe('AIConsentModal', () => {
   beforeEach(() => {
     grantConsentMock.mockReset()
+    // consentPrompt keeps its pending resolver/promise at module scope, so a
+    // test that leaves the prompt unresolved (e.g., the render-only case)
+    // would otherwise pollute the next test's module state across the fresh
+    // store boundary. resolveDecision clears both Vuex and module state.
+    const resetStore = createStore({ modules: { consentPrompt } })
+    resetStore.dispatch('consentPrompt/resolveDecision', false)
   })
 
   it('is hidden when consent prompt is not visible', () => {

--- a/purplex/client/src/i18n/locales/en/auth.json
+++ b/purplex/client/src/i18n/locales/en/auth.json
@@ -99,6 +99,14 @@
         "thirdPartySharing": "Third-Party Data Sharing",
         "researchUse": "Research Data Use",
         "behavioralTracking": "Progress Tracking"
+      },
+      "aiConsentPrompt": {
+        "title": "Enable AI features?",
+        "body": "This activity uses AI to analyze your code and generate feedback. Your submission will be sent to our AI provider for processing. You can change this preference anytime in Privacy settings.",
+        "grant": "Enable AI features",
+        "decline": "Not now",
+        "granting": "Enabling...",
+        "error": "We couldn't enable AI features. Please try again."
       }
     },
     "deletion": {

--- a/purplex/client/src/i18n/locales/en/common.json
+++ b/purplex/client/src/i18n/locales/en/common.json
@@ -120,7 +120,7 @@
       "invalid_input": "Invalid input format. Please check your values.",
       "hint_locked": "This hint is not yet available.",
       "insufficient_attempts": "You need more attempts before this hint unlocks.",
-      "consent_required": "Your consent is required to continue.",
+      "consent_required": "AI processing consent is required to continue.",
       "submission_not_found": "Submission not found."
     }
   },

--- a/purplex/client/src/i18n/locales/en/common.json
+++ b/purplex/client/src/i18n/locales/en/common.json
@@ -120,7 +120,7 @@
       "invalid_input": "Invalid input format. Please check your values.",
       "hint_locked": "This hint is not yet available.",
       "insufficient_attempts": "You need more attempts before this hint unlocks.",
-      "consent_required": "AI processing consent is required to continue.",
+      "consent_required": "Your consent is required to continue.",
       "submission_not_found": "Submission not found."
     }
   },

--- a/purplex/client/src/i18n/locales/es/auth.json
+++ b/purplex/client/src/i18n/locales/es/auth.json
@@ -99,6 +99,14 @@
         "thirdPartySharing": "Compartir Datos con Terceros",
         "researchUse": "Uso de Datos para Investigación",
         "behavioralTracking": "Seguimiento de Progreso"
+      },
+      "aiConsentPrompt": {
+        "title": "Enable AI features?",
+        "body": "This activity uses AI to analyze your code and generate feedback. Your submission will be sent to our AI provider for processing. You can change this preference anytime in Privacy settings.",
+        "grant": "Enable AI features",
+        "decline": "Not now",
+        "granting": "Enabling...",
+        "error": "We couldn't enable AI features. Please try again."
       }
     },
     "deletion": {

--- a/purplex/client/src/i18n/locales/es/common.json
+++ b/purplex/client/src/i18n/locales/es/common.json
@@ -120,7 +120,7 @@
       "invalid_input": "Formato de entrada inválido. Por favor, revisa tus valores.",
       "hint_locked": "Esta pista aún no está disponible.",
       "insufficient_attempts": "Necesitas más intentos antes de que esta pista se desbloquee.",
-      "consent_required": "Se requiere tu consentimiento para continuar.",
+      "consent_required": "AI processing consent is required to continue.",
       "submission_not_found": "Envío no encontrado."
     }
   },

--- a/purplex/client/src/i18n/locales/es/common.json
+++ b/purplex/client/src/i18n/locales/es/common.json
@@ -120,7 +120,7 @@
       "invalid_input": "Formato de entrada inválido. Por favor, revisa tus valores.",
       "hint_locked": "Esta pista aún no está disponible.",
       "insufficient_attempts": "Necesitas más intentos antes de que esta pista se desbloquee.",
-      "consent_required": "AI processing consent is required to continue.",
+      "consent_required": "Se requiere tu consentimiento para continuar.",
       "submission_not_found": "Envío no encontrado."
     }
   },

--- a/purplex/client/src/main.ts
+++ b/purplex/client/src/main.ts
@@ -8,6 +8,7 @@ import { getStoredLocale, i18n, setLocale } from './i18n';
 import { log } from './utils/logger';
 import { environment } from './services/environment';
 import { ensureFirebaseInitialized, firebaseAuth } from './firebaseConfig';
+import { handleConsentRequired, isConsentRequiredError } from './utils/consentInterceptor';
 
 // Configure axios with environment-aware settings
 axios.defaults.withCredentials = true;
@@ -89,6 +90,12 @@ axios.interceptors.response.use(
   },
   async (error) => {
     const originalRequest = error.config;
+
+    // Intercept AI-consent denial BEFORE the 401 path: surface the in-app
+    // grant modal, then retry the original request if the user consents.
+    if (isConsentRequiredError(error)) {
+      return handleConsentRequired(error);
+    }
 
     // If 401 and haven't retried yet, try refreshing token
     if (error.response?.status === 401) {

--- a/purplex/client/src/services/__tests__/privacyService.test.ts
+++ b/purplex/client/src/services/__tests__/privacyService.test.ts
@@ -32,6 +32,25 @@ describe('PrivacyService', () => {
       })
       expect(result.granted).toBe(true)
     })
+
+    it('passes consent_method when provided (in-app modal tags the audit record)', async () => {
+      const mockData = { consent_type: 'ai_processing', granted: true }
+      vi.mocked(axios.post).mockResolvedValue({ data: mockData })
+
+      await privacyService.grantConsent('ai_processing', { consent_method: 'in_app' })
+      expect(axios.post).toHaveBeenCalledWith('/api/users/me/consents/', {
+        consent_type: 'ai_processing',
+        consent_method: 'in_app',
+      })
+    })
+
+    it('omits consent_method from payload when not supplied', async () => {
+      vi.mocked(axios.post).mockResolvedValue({ data: {} })
+
+      await privacyService.grantConsent('ai_processing')
+      const payload = vi.mocked(axios.post).mock.calls[0][1]
+      expect(payload).not.toHaveProperty('consent_method')
+    })
   })
 
   describe('withdrawConsent', () => {

--- a/purplex/client/src/services/privacyService.ts
+++ b/purplex/client/src/services/privacyService.ts
@@ -9,6 +9,10 @@ export type ConsentType =
     | 'research_use'
     | 'behavioral_tracking';
 
+// Only self-service methods are accepted by the grant endpoint; the server
+// rejects institutional/parental to keep the audit trail honest.
+export type ConsentMethod = 'registration' | 'in_app';
+
 export interface ConsentStatus {
     granted: boolean;
     granted_at: string | null;
@@ -61,10 +65,17 @@ class PrivacyService {
         return response.data;
     }
 
-    async grantConsent(consentType: ConsentType): Promise<ConsentRecord> {
-        const response = await axios.post('/api/users/me/consents/', {
+    async grantConsent(
+        consentType: ConsentType,
+        options?: { consent_method?: ConsentMethod },
+    ): Promise<ConsentRecord> {
+        const payload: { consent_type: ConsentType; consent_method?: ConsentMethod } = {
             consent_type: consentType,
-        });
+        };
+        if (options?.consent_method) {
+            payload.consent_method = options.consent_method;
+        }
+        const response = await axios.post('/api/users/me/consents/', payload);
         return response.data;
     }
 

--- a/purplex/client/src/store/__tests__/consentPrompt.module.test.ts
+++ b/purplex/client/src/store/__tests__/consentPrompt.module.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStore, type Store } from 'vuex'
+import { consentPrompt, type ConsentPromptState } from '../consentPrompt.module'
+
+function freshStore(): Store<{ consentPrompt: ConsentPromptState }> {
+  return createStore({ modules: { consentPrompt } })
+}
+
+describe('consentPrompt store module', () => {
+  let store: Store<{ consentPrompt: ConsentPromptState }>
+
+  beforeEach(() => {
+    store = freshStore()
+    // Module-scope promise state leaks across tests — resolve any prior
+    // pending decision so the next test starts from a clean slate.
+    store.dispatch('consentPrompt/resolveDecision', false).catch(() => undefined)
+  })
+
+  describe('requestDecision concurrent behavior', () => {
+    it('shares the same resolution across repeated same-purpose calls', async () => {
+      // Vuex dispatch wraps each call in its own outer promise, so identity
+      // check isn't meaningful. What we care about: both calls resolve to
+      // the same user decision, and only one modal is shown.
+      const first = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+      const second = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+
+      expect(store.state.consentPrompt.visible).toBe(true)
+      expect(store.state.consentPrompt.purpose).toBe('ai_processing')
+
+      store.dispatch('consentPrompt/resolveDecision', true)
+      await expect(first).resolves.toBe(true)
+      await expect(second).resolves.toBe(true)
+    })
+
+    it('rejects a collision call for a different purpose without clobbering the pending one', async () => {
+      const original = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+      const conflicting = store.dispatch(
+        'consentPrompt/requestDecision',
+        'behavioral_tracking',
+      )
+
+      // The conflicting call must reject synchronously — the original must NOT
+      // be affected. This is the whole point of the guard: previously, the
+      // original resolver got overwritten and its awaiters hung forever.
+      await expect(conflicting).rejects.toThrow(/already pending/)
+
+      // Original is still pending and still resolvable.
+      expect(store.state.consentPrompt.visible).toBe(true)
+      expect(store.state.consentPrompt.purpose).toBe('ai_processing')
+
+      store.dispatch('consentPrompt/resolveDecision', true)
+      await expect(original).resolves.toBe(true)
+    })
+  })
+
+  describe('resolveDecision', () => {
+    it('resolves the pending decision and hides the modal', async () => {
+      const pending = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+      store.dispatch('consentPrompt/resolveDecision', true)
+
+      await expect(pending).resolves.toBe(true)
+      expect(store.state.consentPrompt.visible).toBe(false)
+      expect(store.state.consentPrompt.purpose).toBeNull()
+    })
+
+    it('allows a new decision after the previous one is resolved', async () => {
+      const first = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+      store.dispatch('consentPrompt/resolveDecision', false)
+      await first
+
+      const second = store.dispatch('consentPrompt/requestDecision', 'ai_processing')
+      expect(store.state.consentPrompt.visible).toBe(true)
+      store.dispatch('consentPrompt/resolveDecision', true)
+      await expect(second).resolves.toBe(true)
+    })
+  })
+})

--- a/purplex/client/src/store/consentPrompt.module.ts
+++ b/purplex/client/src/store/consentPrompt.module.ts
@@ -1,0 +1,68 @@
+import { ActionContext, Module } from 'vuex';
+
+export interface ConsentPromptState {
+  visible: boolean;
+  purpose: string | null;
+}
+
+type ConsentPromptActionContext = ActionContext<ConsentPromptState, unknown>;
+
+// Promise plumbing kept out of Vuex state so the store stays serializable.
+// A single decision promise is reused across concurrent requests — if two
+// AI-gated calls land at the same time, we want ONE modal, not two.
+let pendingResolver: ((granted: boolean) => void) | null = null;
+let pendingPromise: Promise<boolean> | null = null;
+
+export const consentPrompt: Module<ConsentPromptState, unknown> = {
+  namespaced: true,
+
+  state: (): ConsentPromptState => ({
+    visible: false,
+    purpose: null,
+  }),
+
+  mutations: {
+    show(state: ConsentPromptState, purpose: string) {
+      state.visible = true;
+      state.purpose = purpose;
+    },
+    hide(state: ConsentPromptState) {
+      state.visible = false;
+      state.purpose = null;
+    },
+  },
+
+  actions: {
+    /**
+     * Returns a promise that resolves when the user decides. If a prompt is
+     * already visible for the same purpose, the existing promise is returned
+     * so concurrent AI-gated requests share one decision.
+     */
+    requestDecision(
+      { commit, state }: ConsentPromptActionContext,
+      purpose: string,
+    ): Promise<boolean> {
+      if (pendingPromise && state.purpose === purpose) {
+        return pendingPromise;
+      }
+
+      pendingPromise = new Promise<boolean>((resolve) => {
+        pendingResolver = resolve;
+      });
+      commit('show', purpose);
+      return pendingPromise;
+    },
+
+    /**
+     * Called by the modal UI when the user makes a choice.
+     */
+    resolveDecision({ commit }: ConsentPromptActionContext, granted: boolean) {
+      if (pendingResolver) {
+        pendingResolver(granted);
+      }
+      pendingResolver = null;
+      pendingPromise = null;
+      commit('hide');
+    },
+  },
+};

--- a/purplex/client/src/store/consentPrompt.module.ts
+++ b/purplex/client/src/store/consentPrompt.module.ts
@@ -37,13 +37,26 @@ export const consentPrompt: Module<ConsentPromptState, unknown> = {
      * Returns a promise that resolves when the user decides. If a prompt is
      * already visible for the same purpose, the existing promise is returned
      * so concurrent AI-gated requests share one decision.
+     *
+     * If a prompt is pending for a DIFFERENT purpose, the new call rejects
+     * immediately rather than clobbering the in-flight resolver (which would
+     * leave the original awaiters hanging forever). The store tracks a single
+     * purpose at a time; supporting simultaneous distinct prompts is a scope
+     * change that needs explicit design.
      */
     requestDecision(
       { commit, state }: ConsentPromptActionContext,
       purpose: string,
     ): Promise<boolean> {
-      if (pendingPromise && state.purpose === purpose) {
-        return pendingPromise;
+      if (pendingPromise) {
+        if (state.purpose === purpose) {
+          return pendingPromise;
+        }
+        return Promise.reject(
+          new Error(
+            `consentPrompt: "${state.purpose}" is already pending; cannot start "${purpose}".`,
+          ),
+        );
       }
 
       pendingPromise = new Promise<boolean>((resolve) => {

--- a/purplex/client/src/store/index.ts
+++ b/purplex/client/src/store/index.ts
@@ -1,16 +1,19 @@
 import { createStore, Store } from "vuex";
 import { auth, AuthState } from "./auth.module";
+import { consentPrompt, ConsentPromptState } from "./consentPrompt.module";
 import { courses, CoursesState } from "./courses.module";
 
 export interface RootState {
   auth: AuthState;
   courses: CoursesState;
+  consentPrompt: ConsentPromptState;
 }
 
 const store: Store<RootState> = createStore({
   modules: {
     auth,
     courses,
+    consentPrompt,
   },
 });
 

--- a/purplex/client/src/utils/__tests__/consentInterceptor.test.ts
+++ b/purplex/client/src/utils/__tests__/consentInterceptor.test.ts
@@ -1,6 +1,5 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
-import type { AxiosError } from 'axios'
-import axios from 'axios'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import axios, { type AxiosError } from 'axios'
 import { createStore, type Store } from 'vuex'
 import { consentPrompt, type ConsentPromptState } from '../../store/consentPrompt.module'
 
@@ -125,7 +124,7 @@ describe('handleConsentRequired', () => {
   })
 
   it('deduplicates concurrent requests so one modal serves many 403s', async () => {
-    ;(axios as unknown as Mock).mockResolvedValue({ status: 200, data: {} })
+    (axios as unknown as Mock).mockResolvedValue({ status: 200, data: {} })
 
     const first = handleConsentRequired(consentError({ url: '/api/submit/' }))
     const second = handleConsentRequired(consentError({ url: '/api/submit/' }))

--- a/purplex/client/src/utils/__tests__/consentInterceptor.test.ts
+++ b/purplex/client/src/utils/__tests__/consentInterceptor.test.ts
@@ -46,7 +46,7 @@ function consentError(config: { url?: string; _consentRetried?: boolean } = {}) 
 }
 
 describe('isConsentRequiredError', () => {
-  it('returns true for 403 + consent_required code', () => {
+  it('returns true for 403 + consent_required + purpose=ai_processing', () => {
     expect(isConsentRequiredError(consentError())).toBe(true)
   })
 
@@ -67,14 +67,35 @@ describe('isConsentRequiredError', () => {
   it('returns false when response is missing (network error)', () => {
     expect(isConsentRequiredError({} as AxiosError)).toBe(false)
   })
+
+  it('returns false for consent_required without a purpose field', () => {
+    // The generic consent_required code is used by non-AI gates
+    // (e.g. behavioral_tracking in activity_event_views) that don't set purpose.
+    const err = {
+      response: { status: 403, data: { code: 'consent_required' } },
+    } as unknown as AxiosError
+    expect(isConsentRequiredError(err)).toBe(false)
+  })
+
+  it('returns false for consent_required with a non-AI purpose', () => {
+    const err = {
+      response: {
+        status: 403,
+        data: { code: 'consent_required', purpose: 'behavioral_tracking' },
+      },
+    } as unknown as AxiosError
+    expect(isConsentRequiredError(err)).toBe(false)
+  })
 })
 
 describe('handleConsentRequired', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Reset store state between tests — the module keeps promise plumbing
-    // in module-scope that would otherwise leak across cases.
-    store.commit('consentPrompt/hide')
+    // Module-scope promise plumbing leaks across tests. resolveDecision
+    // clears both Vuex state AND the module-level resolver/promise; the
+    // older `commit('hide')` only cleared Vuex state, leaving the module
+    // globals set and tripping the new purpose-collision guard.
+    store.dispatch('consentPrompt/resolveDecision', false)
   })
 
   it('retries the original request when the user grants consent', async () => {

--- a/purplex/client/src/utils/__tests__/consentInterceptor.test.ts
+++ b/purplex/client/src/utils/__tests__/consentInterceptor.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import type { AxiosError } from 'axios'
+import axios from 'axios'
+import { createStore, type Store } from 'vuex'
+import { consentPrompt, type ConsentPromptState } from '../../store/consentPrompt.module'
+
+// Build a minimal store that exposes only the consentPrompt module. Importing
+// the real `../store` would transitively pull in auth.module.ts which reads
+// localStorage at module load and breaks the test environment.
+const store: Store<{ consentPrompt: ConsentPromptState }> = createStore({
+  modules: { consentPrompt },
+})
+
+vi.mock('../../store', () => ({ default: store }))
+
+vi.mock('../logger', () => ({
+  log: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('axios', async () => {
+  const actual = await vi.importActual<typeof import('axios')>('axios')
+  // Keep the real default export structure but make the top-level function
+  // callable via the same import used inside the interceptor (`axios(config)`).
+  const mockFn = vi.fn() as unknown as typeof axios
+  return {
+    ...actual,
+    default: Object.assign(mockFn, actual.default),
+  }
+})
+
+// Must be imported AFTER the mocks above.
+const { handleConsentRequired, isConsentRequiredError } = await import('../consentInterceptor')
+
+function consentError(config: { url?: string; _consentRetried?: boolean } = {}) {
+  return {
+    config: { url: '/api/submit/', ...config },
+    response: {
+      status: 403,
+      data: {
+        error: 'AI processing consent not granted',
+        code: 'consent_required',
+        purpose: 'ai_processing',
+      },
+    },
+  } as unknown as AxiosError<{ error: string; code: string; purpose: string }>
+}
+
+describe('isConsentRequiredError', () => {
+  it('returns true for 403 + consent_required code', () => {
+    expect(isConsentRequiredError(consentError())).toBe(true)
+  })
+
+  it('returns false for 403 without consent_required code', () => {
+    const err = {
+      response: { status: 403, data: { code: 'forbidden' } },
+    } as unknown as AxiosError
+    expect(isConsentRequiredError(err)).toBe(false)
+  })
+
+  it('returns false for non-403 status', () => {
+    const err = {
+      response: { status: 500, data: { code: 'consent_required' } },
+    } as unknown as AxiosError
+    expect(isConsentRequiredError(err)).toBe(false)
+  })
+
+  it('returns false when response is missing (network error)', () => {
+    expect(isConsentRequiredError({} as AxiosError)).toBe(false)
+  })
+})
+
+describe('handleConsentRequired', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset store state between tests — the module keeps promise plumbing
+    // in module-scope that would otherwise leak across cases.
+    store.commit('consentPrompt/hide')
+  })
+
+  it('retries the original request when the user grants consent', async () => {
+    const retryResponse = { status: 200, data: { ok: true } }
+    ;(axios as unknown as Mock).mockResolvedValue(retryResponse)
+
+    const handlerPromise = handleConsentRequired(consentError())
+
+    // Simulate the user clicking Grant.
+    await Promise.resolve() // let the action register the promise first
+    store.dispatch('consentPrompt/resolveDecision', true)
+
+    const result = await handlerPromise
+    expect(result).toEqual(retryResponse)
+    expect((axios as unknown as Mock)).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects with the original error when the user declines', async () => {
+    const err = consentError()
+    const handlerPromise = handleConsentRequired(err)
+
+    await Promise.resolve()
+    store.dispatch('consentPrompt/resolveDecision', false)
+
+    await expect(handlerPromise).rejects.toBe(err)
+    expect((axios as unknown as Mock)).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates concurrent requests so one modal serves many 403s', async () => {
+    ;(axios as unknown as Mock).mockResolvedValue({ status: 200, data: {} })
+
+    const first = handleConsentRequired(consentError({ url: '/api/submit/' }))
+    const second = handleConsentRequired(consentError({ url: '/api/submit/' }))
+    await Promise.resolve()
+
+    // Only one prompt is visible — both requests are waiting on the same promise.
+    expect(store.state.consentPrompt.visible).toBe(true)
+
+    store.dispatch('consentPrompt/resolveDecision', true)
+
+    await first
+    await second
+    expect((axios as unknown as Mock)).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not loop when a retried request also returns consent_required', async () => {
+    const retriedError = consentError({ _consentRetried: true })
+    await expect(handleConsentRequired(retriedError)).rejects.toBe(retriedError)
+    expect((axios as unknown as Mock)).not.toHaveBeenCalled()
+    // Modal should never have been shown for a retry-loop case.
+    expect(store.state.consentPrompt.visible).toBe(false)
+  })
+
+  it('rejects without prompting when the error has no purpose field', async () => {
+    const err = {
+      config: { url: '/api/submit/' },
+      response: { status: 403, data: { code: 'consent_required' } },
+    } as unknown as AxiosError<{ code: string }>
+    await expect(handleConsentRequired(err as unknown as AxiosError)).rejects.toBe(err)
+    expect(store.state.consentPrompt.visible).toBe(false)
+  })
+})

--- a/purplex/client/src/utils/consentInterceptor.ts
+++ b/purplex/client/src/utils/consentInterceptor.ts
@@ -1,5 +1,8 @@
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
-import axios from 'axios';
+import axios, {
+  type AxiosError,
+  type AxiosRequestConfig,
+  type AxiosResponse,
+} from 'axios';
 import store from '../store';
 import { log } from './logger';
 

--- a/purplex/client/src/utils/consentInterceptor.ts
+++ b/purplex/client/src/utils/consentInterceptor.ts
@@ -1,0 +1,66 @@
+import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios from 'axios';
+import store from '../store';
+import { log } from './logger';
+
+interface ConsentRequiredErrorBody {
+  error: string;
+  code: string;
+  purpose: string;
+}
+
+type ConsentAwareConfig = AxiosRequestConfig & { _consentRetried?: boolean };
+
+/**
+ * Detects `403 + code=consent_required` from the backend and coordinates with
+ * the AIConsentModal to let the user grant consent and retry the original
+ * request. Resolves with the retried response, or rejects with the original
+ * error if the user declines or retry itself fails.
+ *
+ * Concurrent-call dedup lives in the consentPrompt store — we just await its
+ * promise here, so N simultaneous 403s produce ONE modal.
+ *
+ * The `_consentRetried` flag on the request config prevents an infinite loop
+ * if the retry itself somehow still returns 403 (e.g., grant silently failed,
+ * policy-version bump server-side).
+ */
+export async function handleConsentRequired(
+  error: AxiosError<ConsentRequiredErrorBody>,
+): Promise<AxiosResponse> {
+  const originalRequest = error.config as ConsentAwareConfig | undefined;
+  if (!originalRequest || originalRequest._consentRetried) {
+    return Promise.reject(error);
+  }
+
+  const purpose = error.response?.data?.purpose;
+  if (!purpose) {
+    log.error('Consent-required error missing purpose field', error.response?.data);
+    return Promise.reject(error);
+  }
+
+  const granted: boolean = await store.dispatch(
+    'consentPrompt/requestDecision',
+    purpose,
+  );
+
+  if (!granted) {
+    return Promise.reject(error);
+  }
+
+  originalRequest._consentRetried = true;
+  return axios(originalRequest);
+}
+
+/**
+ * Predicate for the response interceptor wiring. Kept exported so tests can
+ * assert on detection logic without mocking the full axios stack.
+ */
+export function isConsentRequiredError(
+  error: AxiosError<Partial<ConsentRequiredErrorBody>> | AxiosError,
+): boolean {
+  return (
+    error.response?.status === 403 &&
+    (error.response?.data as Partial<ConsentRequiredErrorBody> | undefined)?.code ===
+      'consent_required'
+  );
+}

--- a/purplex/client/src/utils/consentInterceptor.ts
+++ b/purplex/client/src/utils/consentInterceptor.ts
@@ -54,13 +54,20 @@ export async function handleConsentRequired(
 /**
  * Predicate for the response interceptor wiring. Kept exported so tests can
  * assert on detection logic without mocking the full axios stack.
+ *
+ * The backend's `consent_required` error code is generic — it's also returned
+ * for non-AI gates like behavioral_tracking (see activity_event_views.py). We
+ * match on `purpose === 'ai_processing'` so only AI-consent denials trigger
+ * the modal/retry flow; other consent 403s fall through to normal error
+ * handling.
  */
 export function isConsentRequiredError(
   error: AxiosError<Partial<ConsentRequiredErrorBody>> | AxiosError,
 ): boolean {
+  const data = error.response?.data as Partial<ConsentRequiredErrorBody> | undefined;
   return (
     error.response?.status === 403 &&
-    (error.response?.data as Partial<ConsentRequiredErrorBody> | undefined)?.code ===
-      'consent_required'
+    data?.code === 'consent_required' &&
+    data?.purpose === 'ai_processing'
   );
 }

--- a/purplex/problems_app/handlers/base.py
+++ b/purplex/problems_app/handlers/base.py
@@ -235,6 +235,18 @@ class ActivityHandler(ABC):
         """
         pass
 
+    # ─── Policy Declarations ────────────────────────────────────
+
+    def requires_ai_consent(self) -> bool:
+        """
+        Whether this activity type sends user input through AI processing.
+
+        Handlers that invoke LLM calls (EiPL, Prompt, etc.) should override
+        to return True. The submission view gates on this before creating a
+        Submission row so denial produces a structured 403 without orphan data.
+        """
+        return False
+
     # ─── Optional Hooks ─────────────────────────────────────────
 
     def on_submission_created(self, submission: "Submission") -> None:

--- a/purplex/problems_app/handlers/eipl/handler.py
+++ b/purplex/problems_app/handlers/eipl/handler.py
@@ -319,6 +319,9 @@ class EiPLHandler(ActivityHandler):
 
     # ─── Submission Execution ─────────────────────────────────────
 
+    def requires_ai_consent(self) -> bool:
+        return True
+
     def submit(
         self,
         submission: "Submission",

--- a/purplex/problems_app/views/submission_views.py
+++ b/purplex/problems_app/views/submission_views.py
@@ -91,6 +91,18 @@ class ActivitySubmissionView(APIView):
 
         handler = get_handler(problem_type)
 
+        # Pre-flight AI consent check. Done here (before submission creation) so
+        # denial produces a structured 403 via the custom exception handler
+        # without leaving an orphan Submission row. The Celery pipeline also
+        # checks consent as defense-in-depth for any bypass path.
+        if handler.requires_ai_consent():
+            from django.conf import settings as django_settings
+
+            from purplex.users_app.services.consent_service import ConsentService
+
+            if getattr(django_settings, "PRIVACY_ENABLE_AI_CONSENT_GATE", False):
+                ConsentService.check_ai_consent(request.user)
+
         logger.info(
             f"Activity submission for {problem_type} problem {problem.slug} by user {request.user.username}"
         )

--- a/purplex/users_app/views/privacy_views.py
+++ b/purplex/users_app/views/privacy_views.py
@@ -141,7 +141,13 @@ class ConsentListView(APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        if consent_method not in ALLOWED_SELF_SERVICE_CONSENT_METHODS:
+        # isinstance check guards against non-hashable JSON values (list/dict),
+        # which would otherwise raise TypeError on the frozenset membership test
+        # and surface as a 500 via the exception handler's catch-all.
+        if (
+            not isinstance(consent_method, str)
+            or consent_method not in ALLOWED_SELF_SERVICE_CONSENT_METHODS
+        ):
             return error_response(
                 "Invalid consent_method. Must be 'registration' or 'in_app'.",
                 ErrorCode.VALIDATION_ERROR,

--- a/purplex/users_app/views/privacy_views.py
+++ b/purplex/users_app/views/privacy_views.py
@@ -20,6 +20,7 @@ from purplex.utils.error_codes import ErrorCode, error_response
 from ..models import (
     AgeVerification,
     AuditAction,
+    ConsentMethod,
     ConsentType,
     DataAccessAuditLog,
     DataPrincipalNominee,
@@ -32,6 +33,13 @@ from ..services.data_export_service import DataExportService
 from ..utils.request_helpers import get_client_ip as _get_client_ip
 
 logger = logging.getLogger(__name__)
+
+# Only self-service consent methods can be supplied by the client.
+# INSTITUTIONAL and PARENTAL imply a third party granted consent and must be
+# set server-side via other code paths.
+ALLOWED_SELF_SERVICE_CONSENT_METHODS = frozenset(
+    [ConsentMethod.REGISTRATION, ConsentMethod.IN_APP]
+)
 
 
 class DataExportView(APIView):
@@ -115,6 +123,7 @@ class ConsentListView(APIView):
     def post(self, request):
         """Grant consent for a specific type."""
         consent_type = request.data.get("consent_type")
+        consent_method = request.data.get("consent_method", ConsentMethod.REGISTRATION)
         ip = _get_client_ip(request)
 
         if not consent_type:
@@ -132,10 +141,18 @@ class ConsentListView(APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
+        if consent_method not in ALLOWED_SELF_SERVICE_CONSENT_METHODS:
+            return error_response(
+                "Invalid consent_method. Must be 'registration' or 'in_app'.",
+                ErrorCode.VALIDATION_ERROR,
+                status.HTTP_400_BAD_REQUEST,
+            )
+
         consent = ConsentService.grant_consent(
             user=request.user,
             consent_type=consent_type,
             ip_address=ip,
+            consent_method=consent_method,
         )
 
         return Response(

--- a/purplex/utils/exception_handler.py
+++ b/purplex/utils/exception_handler.py
@@ -18,6 +18,22 @@ logger = logging.getLogger(__name__)
 
 
 def custom_exception_handler(exc, context):
+    # Lazy import to avoid circular dependency (users_app.services imports models).
+    from purplex.users_app.services.consent_service import AIConsentNotGrantedError
+    from purplex.utils.error_codes import ErrorCode
+
+    # Map consent-denial to a structured 403 so the frontend can surface the
+    # in-app grant modal instead of a dead-end error.
+    if isinstance(exc, AIConsentNotGrantedError):
+        return Response(
+            {
+                "error": str(exc),
+                "code": ErrorCode.CONSENT_REQUIRED,
+                "purpose": "ai_processing",
+            },
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
     # Let DRF handle its own exceptions first (ValidationError, NotAuthenticated, etc.)
     response = drf_default_handler(exc, context)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,35 @@ def user_with_all_consents(db):
 
 
 @pytest.fixture
+def user_without_ai_consent(db):
+    """Create a user with profile but no AI_PROCESSING consent record.
+
+    Represents both pre-consent-framework accounts and freshly created accounts
+    before the first in-app AI consent prompt. Used to exercise the denial path.
+    """
+    u = UserFactory(username="no_ai_consent_user")
+    UserProfileFactory(user=u)
+    return u
+
+
+@pytest.fixture
+def ai_consented_user(db):
+    """User with profile and a granted AI_PROCESSING consent record.
+
+    Use this for tests that exercise the happy path of AI-gated submission
+    flows (EiPL, prompt, etc.). For the denial path, use
+    `user_without_ai_consent` instead. For tests that need consent across
+    every purpose at once, see `user_with_all_consents`.
+    """
+    from purplex.users_app.models import ConsentType
+
+    u = UserFactory(username="ai_consented_user")
+    UserProfileFactory(user=u)
+    UserConsentFactory(user=u, consent_type=ConsentType.AI_PROCESSING)
+    return u
+
+
+@pytest.fixture
 def user_with_deletion_requested(db):
     """Create a user with a pending deletion (inactive, scheduled in the past)."""
     from datetime import timedelta

--- a/tests/integration/test_eipl_submission_consent.py
+++ b/tests/integration/test_eipl_submission_consent.py
@@ -1,0 +1,165 @@
+"""
+Integration tests for the AI-consent gate on POST /api/submit/.
+
+The check runs in the view before the Submission row is created. Denial surfaces
+as a structured 403 via the custom exception handler so the frontend can route
+it to the in-app grant modal instead of an opaque failure.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+
+from purplex.users_app.models import ConsentType
+from tests.factories import (
+    AgeVerificationFactory,
+    CourseEnrollmentFactory,
+    CourseFactory,
+    CourseProblemSetFactory,
+    EiplProblemFactory,
+    McqProblemFactory,
+    ProblemSetFactory,
+    ProblemSetMembershipFactory,
+    TestCaseFactory,
+    UserConsentFactory,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+SUBMIT_URL = reverse("submit_activity")
+EIPL_PIPELINE = "purplex.problems_app.tasks.pipeline.execute_eipl_pipeline"
+
+
+def _enroll(user):
+    course = CourseFactory()
+    CourseEnrollmentFactory(user=user, course=course)
+    problem_set = ProblemSetFactory()
+    CourseProblemSetFactory(course=course, problem_set=problem_set)
+    return course, problem_set
+
+
+def _submit(client, problem, problem_set, course, raw_input):
+    return client.post(
+        SUBMIT_URL,
+        {
+            "problem_slug": problem.slug,
+            "raw_input": raw_input,
+            "problem_set_slug": problem_set.slug,
+            "course_id": course.course_id,
+        },
+        format="json",
+    )
+
+
+class TestEiPLSubmissionConsentGate:
+    """POST /api/submit/ must reject AI-processing submissions from users who
+    haven't granted ai_processing consent, and accept them otherwise."""
+
+    EIPL_INPUT = "This is a valid description of what the code does."
+
+    def test_without_consent_returns_structured_403(
+        self, api_client, user_without_ai_consent
+    ):
+        course, problem_set = _enroll(user_without_ai_consent)
+        problem = EiplProblemFactory()
+        ProblemSetMembershipFactory(problem_set=problem_set, problem=problem)
+        TestCaseFactory(problem=problem, inputs=[1], expected_output=2)
+
+        api_client.force_authenticate(user=user_without_ai_consent)
+        response = _submit(api_client, problem, problem_set, course, self.EIPL_INPUT)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data["code"] == "consent_required"
+        assert response.data["purpose"] == "ai_processing"
+        assert "error" in response.data
+
+    def test_with_consent_returns_202(self, api_client, user):
+        course, problem_set = _enroll(user)
+        UserConsentFactory(user=user, consent_type=ConsentType.AI_PROCESSING)
+
+        problem = EiplProblemFactory()
+        ProblemSetMembershipFactory(problem_set=problem_set, problem=problem)
+        TestCaseFactory(problem=problem, inputs=[1], expected_output=2)
+
+        api_client.force_authenticate(user=user)
+
+        mock_task = MagicMock(id="test-task-id")
+        with patch(f"{EIPL_PIPELINE}.apply_async", return_value=mock_task):
+            response = _submit(
+                api_client, problem, problem_set, course, self.EIPL_INPUT
+            )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.data["status"] == "processing"
+
+    def test_minor_without_parental_consent_returns_403(self, api_client, user):
+        course, problem_set = _enroll(user)
+        UserConsentFactory(user=user, consent_type=ConsentType.AI_PROCESSING)
+        AgeVerificationFactory(user=user, is_minor=True, parental_consent_given=False)
+
+        problem = EiplProblemFactory()
+        ProblemSetMembershipFactory(problem_set=problem_set, problem=problem)
+        TestCaseFactory(problem=problem, inputs=[1], expected_output=2)
+
+        api_client.force_authenticate(user=user)
+        response = _submit(api_client, problem, problem_set, course, self.EIPL_INPUT)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data["code"] == "consent_required"
+        assert "Parental consent" in response.data["error"]
+
+    def test_mcq_unaffected_by_missing_ai_consent(
+        self, api_client, user_without_ai_consent
+    ):
+        """MCQ does not route through AI processing, so the gate must not fire.
+        Regression guard: a bug adding the check to all submission types would
+        break non-AI activities."""
+        course, problem_set = _enroll(user_without_ai_consent)
+        problem = McqProblemFactory()
+        ProblemSetMembershipFactory(problem_set=problem_set, problem=problem)
+
+        api_client.force_authenticate(user=user_without_ai_consent)
+        response = _submit(api_client, problem, problem_set, course, "b")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "complete"
+
+    @override_settings(PRIVACY_ENABLE_AI_CONSENT_GATE=False)
+    def test_gate_disabled_allows_submission(self, api_client, user_without_ai_consent):
+        """With the feature flag off, submissions proceed even without consent.
+        The flag exists as a kill-switch for emergencies."""
+        course, problem_set = _enroll(user_without_ai_consent)
+        problem = EiplProblemFactory()
+        ProblemSetMembershipFactory(problem_set=problem_set, problem=problem)
+        TestCaseFactory(problem=problem, inputs=[1], expected_output=2)
+
+        api_client.force_authenticate(user=user_without_ai_consent)
+
+        mock_task = MagicMock(id="test-task-id")
+        with patch(f"{EIPL_PIPELINE}.apply_async", return_value=mock_task):
+            response = _submit(
+                api_client, problem, problem_set, course, self.EIPL_INPUT
+            )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+
+    def test_no_orphan_submission_when_consent_denied(
+        self, api_client, user_without_ai_consent
+    ):
+        """Consent check runs BEFORE create_submission, so denial must not leave
+        a dangling Submission row."""
+        from purplex.submissions.models import Submission
+
+        course, problem_set = _enroll(user_without_ai_consent)
+        problem = EiplProblemFactory()
+        ProblemSetMembershipFactory(problem_set=problem_set, problem=problem)
+        TestCaseFactory(problem=problem, inputs=[1], expected_output=2)
+
+        api_client.force_authenticate(user=user_without_ai_consent)
+        response = _submit(api_client, problem, problem_set, course, self.EIPL_INPUT)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert Submission.objects.filter(user=user_without_ai_consent).count() == 0

--- a/tests/integration/test_privacy_consent_api.py
+++ b/tests/integration/test_privacy_consent_api.py
@@ -10,7 +10,7 @@ Endpoints:
 import pytest
 from rest_framework import status
 
-from purplex.users_app.models import ConsentType
+from purplex.users_app.models import ConsentMethod, ConsentType, UserConsent
 from tests.factories import UserConsentFactory
 
 pytestmark = [pytest.mark.integration, pytest.mark.django_db]
@@ -57,6 +57,71 @@ class TestConsentListAPI:
         response = authenticated_client.post(
             "/api/users/me/consents/",
             {"consent_type": "invalid_type"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_post_defaults_to_registration_method(self, authenticated_client, user):
+        """Without consent_method in the body, audit record is tagged REGISTRATION."""
+        response = authenticated_client.post(
+            "/api/users/me/consents/",
+            {"consent_type": ConsentType.AI_PROCESSING},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        record = UserConsent.objects.filter(
+            user=user, consent_type=ConsentType.AI_PROCESSING
+        ).latest("granted_at")
+        assert record.consent_method == ConsentMethod.REGISTRATION
+
+    def test_post_accepts_in_app_consent_method(self, authenticated_client, user):
+        """The in-app consent modal passes consent_method=in_app for an accurate
+        audit trail."""
+        response = authenticated_client.post(
+            "/api/users/me/consents/",
+            {
+                "consent_type": ConsentType.AI_PROCESSING,
+                "consent_method": ConsentMethod.IN_APP,
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        record = UserConsent.objects.filter(
+            user=user, consent_type=ConsentType.AI_PROCESSING
+        ).latest("granted_at")
+        assert record.consent_method == ConsentMethod.IN_APP
+
+    def test_post_rejects_institutional_consent_method(self, authenticated_client):
+        """Self-service consent cannot claim institutional grant — that must be
+        server-set to keep the audit trail honest."""
+        response = authenticated_client.post(
+            "/api/users/me/consents/",
+            {
+                "consent_type": ConsentType.AI_PROCESSING,
+                "consent_method": ConsentMethod.INSTITUTIONAL,
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_post_rejects_parental_consent_method(self, authenticated_client):
+        response = authenticated_client.post(
+            "/api/users/me/consents/",
+            {
+                "consent_type": ConsentType.AI_PROCESSING,
+                "consent_method": ConsentMethod.PARENTAL,
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_post_rejects_unknown_consent_method(self, authenticated_client):
+        response = authenticated_client.post(
+            "/api/users/me/consents/",
+            {
+                "consent_type": ConsentType.AI_PROCESSING,
+                "consent_method": "bogus",
+            },
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/integration/test_privacy_consent_api.py
+++ b/tests/integration/test_privacy_consent_api.py
@@ -126,6 +126,24 @@ class TestConsentListAPI:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_post_rejects_non_string_consent_method(self, authenticated_client):
+        """Non-hashable values (list, dict) would raise TypeError on the
+        frozenset membership test and surface as a 500 without the isinstance
+        guard. Attacker-supplied JSON must fail closed with a clean 400."""
+        for bad_value in ([1, 2], {"x": 1}, 42, True):
+            response = authenticated_client.post(
+                "/api/users/me/consents/",
+                {
+                    "consent_type": ConsentType.AI_PROCESSING,
+                    "consent_method": bad_value,
+                },
+                format="json",
+            )
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+                f"consent_method={bad_value!r} should yield 400, "
+                f"got {response.status_code}"
+            )
+
 
 class TestConsentWithdrawAPI:
     """Tests for DELETE /api/users/me/consents/<consent_type>/."""

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -114,6 +114,42 @@ class TestExceptionHandlerMapping:
         assert response.status_code == 405
         assert "error" in response.data
 
+    # -- AI consent denial --
+
+    def test_ai_consent_error_returns_structured_403(self, handler_context):
+        """AIConsentNotGrantedError must surface as 403 + code=consent_required
+        so the frontend can route it to the in-app grant modal instead of a
+        dead-end error."""
+        from purplex.users_app.services.consent_service import AIConsentNotGrantedError
+
+        response = custom_exception_handler(
+            AIConsentNotGrantedError("User has not consented to AI processing"),
+            handler_context,
+        )
+        assert response is not None
+        assert response.status_code == 403
+        assert response.data == {
+            "error": "User has not consented to AI processing",
+            "code": "consent_required",
+            "purpose": "ai_processing",
+        }
+
+    def test_ai_consent_error_for_minor_preserves_message(self, handler_context):
+        """Parental-consent message (distinct from the generic message) must
+        reach the client unchanged."""
+        from purplex.users_app.services.consent_service import AIConsentNotGrantedError
+
+        response = custom_exception_handler(
+            AIConsentNotGrantedError(
+                "Parental consent required for AI processing of minor's data"
+            ),
+            handler_context,
+        )
+        assert response is not None
+        assert response.status_code == 403
+        assert response.data["code"] == "consent_required"
+        assert "Parental consent" in response.data["error"]
+
     # -- Unknown exceptions: catch-all JSON 500 --
 
     def test_unhandled_exception_returns_500(self, handler_context):

--- a/tests/unit/test_submission_view.py
+++ b/tests/unit/test_submission_view.py
@@ -26,8 +26,6 @@ from tests.factories import (
     PromptProblemFactory,
     RefuteProblemFactory,
     TestCaseFactory,
-    UserFactory,
-    UserProfileFactory,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.django_db]
@@ -46,15 +44,20 @@ PROGRESS_SERVICE = "purplex.problems_app.services.progress_service.ProgressServi
 
 
 @pytest.fixture
-def enrolled_user():
-    """User enrolled in a course with a problem set."""
-    user = UserFactory()
-    UserProfileFactory(user=user)
+def enrolled_user(ai_consented_user):
+    """User with AI_PROCESSING consent, enrolled in a course with a problem set.
+
+    Composed on `ai_consented_user` so the consent dependency is an explicit
+    named fixture rather than a silent grant. Tests exercising AI-consent
+    denial should depend on `user_without_ai_consent` instead — see
+    `tests/integration/test_eipl_submission_consent.py` for the canonical
+    pattern.
+    """
     course = CourseFactory()
-    CourseEnrollmentFactory(user=user, course=course)
+    CourseEnrollmentFactory(user=ai_consented_user, course=course)
     problem_set = ProblemSetFactory()
     CourseProblemSetFactory(course=course, problem_set=problem_set)
-    return {"user": user, "course": course, "problem_set": problem_set}
+    return {"user": ai_consented_user, "course": course, "problem_set": problem_set}
 
 
 @pytest.fixture
@@ -104,9 +107,9 @@ class TestMCQSubmissionView:
             course_id=enrolled_user["course"].course_id,
         )
 
-        assert (
-            response.status_code == 200
-        ), f"Expected 200, got {response.status_code}: {response.data}"
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.data}"
+        )
         assert response.data["status"] == "complete"
         assert response.data["is_correct"] is True
         assert response.data["problem_type"] == "mcq"
@@ -238,9 +241,9 @@ class TestAsyncSubmissionView:
                 course_id=enrolled_user["course"].course_id,
             )
 
-        assert (
-            response.status_code == 202
-        ), f"{handler_type}: expected 202, got {response.status_code}: {response.data}"
+        assert response.status_code == 202, (
+            f"{handler_type}: expected 202, got {response.status_code}: {response.data}"
+        )
         assert response.data["status"] == "processing"
         assert "task_id" in response.data
 


### PR DESCRIPTION
## Summary

Closes #121.

- Users without `ai_processing` consent (pre-consent-framework accounts, new signups before first AI-gated action) hit a raw `"AI processing consent not granted"` error with no path to grant from the UI. This replaces the dead-end with a **structured 403 → modal → grant → retry** flow.
- The in-app grant is tagged `consent_method=in_app` in the audit trail, distinguishable from registration-time grants.
- EiPL stays behind a view-level `handler.requires_ai_consent()` gate — MCQ/Refute/other handlers are unaffected. The Celery-pipeline consent check stays in place as defense-in-depth.
- Consent method is now whitelisted server-side (`registration` / `in_app` only) to keep the audit trail honest — `institutional`/`parental` remain server-set.

## What's in the diff

**Backend**: `exception_handler.py` surfaces `AIConsentNotGrantedError` as `{error, code=consent_required, purpose=ai_processing}`; `submission_views.py` runs the pre-flight check *before* creating a `Submission` row (no orphan rows on denial); `privacy_views.py::ConsentListView.post` accepts optional `consent_method`; `handlers/base.py` gains a `requires_ai_consent()` hook, `EiPLHandler` overrides to `True`.

**Frontend**: New `consentPrompt` Vuex module (single shared decision Promise dedups concurrent 403s), `AIConsentModal.vue` (Teleport, matches `ConfirmDialog` pattern), `consentInterceptor.ts` (axios response branch + retry via `axios(error.config)`, `_consentRetried` flag guards against loops). `privacyService.grantConsent` takes optional `{ consent_method }`. English i18n keys added; Spanish locales get English placeholders pending translation.

**Tests**: 8 new backend cases (exception handler shape, consent_method whitelist, orphan-row guard, kill-switch via `PRIVACY_ENABLE_AI_CONSENT_GATE=False`, MCQ-not-gated regression), 16 new frontend cases (interceptor dedup/retry/decline/loop-guard, modal grant/decline/error, service `consent_method` pass-through), new E2E at `e2e/student/ai-consent-modal.spec.ts`. New `ai_consented_user` fixture in `conftest.py` composed into `test_submission_view.py::enrolled_user` so the consent dependency is a named fixture, not a silent grant.

## Test plan

- [ ] `pytest tests/unit/test_exception_handler.py tests/integration/test_privacy_consent_api.py tests/integration/test_eipl_submission_consent.py tests/unit/test_ai_consent_gate.py tests/unit/test_submission_view.py` — all green locally (67 tests)
- [ ] `pytest -m architecture` — 49 green locally
- [ ] `cd purplex/client && npx vitest run src/services/__tests__/privacyService.test.ts src/utils/__tests__/consentInterceptor.test.ts src/components/privacy/__tests__/AIConsentModal.test.ts` — 30 green locally
- [ ] E2E: `cd purplex/client && npx playwright test ../../e2e/student/ai-consent-modal.spec.ts` with `./start.sh` running (not run locally in this branch; CI/reviewer verification)
- [ ] Manual smoke: log in as an account without AI consent, submit an EiPL → modal appears → Enable → submission proceeds → verify `UserConsent` row has `consent_method='in_app'`

## Out of scope / follow-ups

- AI hint endpoints are not gated (hints are human-authored content, not AI-generated at request time — per confirmation from @dhsmith4).
- Non-English consent modal strings are placeholders; proper translations can follow in a separate PR.
- The parallel silent-grant wart in `tests/integration/test_activity_event_api.py:86-88` (for `BEHAVIORAL_TRACKING` consent) is left alone — worth a follow-up issue to adopt the same `<purpose>_consented_user` fixture pattern.
- Separately noted: the research export view (`ResearchDataExportView`) defaults `anonymize=False` while the underlying service defaults `anonymize=True` — that's a footgun but independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)