### PR TITLE
Stop double-firing hint.track when a hint is opened

### DIFF
--- a/purplex/client/src/features/problems/ProblemSet.vue
+++ b/purplex/client/src/features/problems/ProblemSet.vue
@@ -2098,14 +2098,6 @@ export default {
                     const success = await this.applyHint(hintType, hintData);
                     if (success) {
                         this.logger.info('Applied hint', { hintType });
-
-                        // Track hint usage for backend submission
-                        this.onHintUsed({
-                            problemSlug: this.getCurrentProblem().slug,
-                            hintType: hintType,
-                            timestamp: new Date().toISOString()
-                        });
-
                     } else {
                         this.logger.error('Failed to apply hint', { hintType });
                     }


### PR DESCRIPTION
## Summary

A single hint-button click was inserting **two** `hint.track` `ActivityEvent` rows with identical payloads ~0.4-27ms apart. Confirmed on prod 2026-05-17: 7 of 9 hint opens by davidsmith duped. This PR removes the redundant call so the platform emits exactly one event per click.

## Root cause

`HintButton.toggleHint` fires two emits per click — `'hint-used'` (from `requestHintContent` on success) and `'hint-toggled'` (after the cache check). ProblemSet listens to both, and each lands in `onHintUsed → trackHintUsage`:

```
toggleHint
 ├─ requestHintContent → emit 'hint-used'  → onHintUsed → trackHintUsage  POST #1
 └─ emit 'hint-toggled' (isActive:true)    → onHintToggled
                                              └─ applyHint → onHintUsed → trackHintUsage  POST #2 ← dup
```

The 2/9 opens today that *didn't* dup were `applyHint()` falsy returns — a separate latent bug, filed as #127.

## Change

Six-line delete in `ProblemSet.vue` (lines 2099-2107): remove the redundant `onHintUsed` call inside `onHintToggled`'s `applyHint` success branch. `onHintToggled` becomes purely about applying the hint to the editor; the `'hint-used'` event remains the canonical telemetry trigger.

`currentAttemptHints` (the set of hints active for the in-progress submission) is unaffected — it's still maintained by the surviving `onHintUsed` invocation.

## Impact

| Scenario | Before | After |
|---|---|---|
| Hint open, `applyHint` succeeds | 2 `hint.track` rows | **1** row |
| Hint open, `applyHint` returns falsy (see #127) | 1 row | 1 row |
| Hint open, `requestHintContent` fails (403, network) | 0 rows | 0 rows |

Auckland Compsci101 study (starts 2026-05-18) benefits: Kate's analysis no longer needs to dedupe the `hint.track` stream.

## Test plan

- [ ] CI lint passes (couldn't run locally — eslint deps not installed on the deploy server).
- [ ] After deploy, log in as davidsmith, open any COMPSCI101A-F course, click each hint button on a problem. Confirm exactly one `hint.track` row per click via:
  ```bash
  docker compose -f config/docker/production.yml exec -T app python manage.py shell -c "
  from django.contrib.auth.models import User
  from django.utils import timezone
  from datetime import timedelta
  from purplex.submissions.models import ActivityEvent
  u = User.objects.get(username='davidsmith')
  since = timezone.now() - timedelta(minutes=10)
  for r in ActivityEvent.objects.filter(user=u, event_type='hint.track', timestamp__gte=since).order_by('timestamp'):
      print(r.timestamp.isoformat(), r.problem.slug if r.problem_id else '-', r.payload.get('hint_type'))
  "
  ```
- [ ] Confirm hint UI still opens/applies/removes correctly (the change only drops a duplicated telemetry call, no UX-visible behavior changes).

## Related

- Diagnosis surfaced while verifying Auckland Compsci101 lab seed data (master commits 586b5bf / 3b9572a / 29ba9d9).
- Follow-up: #127 (applyHint silent failures).
- Related cleanup: #126 (drop unused HintActivation telemetry fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)