### PR TITLE
Attribute hint.view events to course and problem FKs

### DIFF
--- a/purplex/client/src/components/HintButton.vue
+++ b/purplex/client/src/components/HintButton.vue
@@ -329,7 +329,10 @@ export default {
 
       this.loading = true
       try {
-        const response = await problemService.getHintContent(this.problemSlug, hintType)
+        const response = await problemService.getHintContent(this.problemSlug, hintType, {
+          courseId: this.courseId,
+          problemSetSlug: this.problemSetSlug
+        })
 
         // Validate that we're still on the same problem after async operation
         if (this.problemSlug !== requestProblemSlug) {
@@ -378,7 +381,10 @@ export default {
         // Store the current problem slug to validate against
         const loadProblemSlug = this.problemSlug
 
-        const response = await problemService.getHintContent(this.problemSlug, hintType)
+        const response = await problemService.getHintContent(this.problemSlug, hintType, {
+          courseId: this.courseId,
+          problemSetSlug: this.problemSetSlug
+        })
 
         // Validate that we're still on the same problem after async operation
         if (this.problemSlug !== loadProblemSlug) {

--- a/purplex/client/src/services/__tests__/problemService.test.ts
+++ b/purplex/client/src/services/__tests__/problemService.test.ts
@@ -410,7 +410,28 @@ describe('ProblemService', () => {
         const result = await problemService.getHintContent('two-sum', 'variable_fade')
 
         expect(axios.get).toHaveBeenCalledWith(
-          '/api/problems/two-sum/hints/variable_fade/'
+          '/api/problems/two-sum/hints/variable_fade/',
+          { params: {} }
+        )
+        expect(result).toEqual(mockHintContent)
+      })
+
+      it('should forward course context as query params', async () => {
+        (axios.get as Mock).mockResolvedValue({ data: mockHintContent })
+
+        const result = await problemService.getHintContent('two-sum', 'variable_fade', {
+          courseId: 'cs101',
+          problemSetSlug: 'week-1'
+        })
+
+        expect(axios.get).toHaveBeenCalledWith(
+          '/api/problems/two-sum/hints/variable_fade/',
+          {
+            params: {
+              course_id: 'cs101',
+              problem_set_slug: 'week-1'
+            }
+          }
         )
         expect(result).toEqual(mockHintContent)
       })

--- a/purplex/client/src/services/problemService.ts
+++ b/purplex/client/src/services/problemService.ts
@@ -279,20 +279,32 @@ class ProblemServiceImpl {
    * Get specific hint content for a problem
    * @param problemSlug - Problem slug identifier
    * @param hintType - Type of hint to retrieve
+   * @param context - Optional course context (forwarded as query params so the
+   *   backend can attribute the resulting hint.view ActivityEvent to a course)
    * @returns Promise resolving to hint content
    * @throws APIError on request failure
    */
   async getHintContent(
     problemSlug: string,
-    hintType: 'variable_fade' | 'subgoal_highlight' | 'suggested_trace'
+    hintType: 'variable_fade' | 'subgoal_highlight' | 'suggested_trace',
+    context?: { courseId?: string; problemSetSlug?: string }
   ): Promise<{
     type: string;
     content: Record<string, unknown>;
     min_attempts: number;
   }> {
     try {
+      const params: Record<string, string> = {};
+      if (context?.courseId) {
+        params.course_id = context.courseId;
+      }
+      if (context?.problemSetSlug) {
+        params.problem_set_slug = context.problemSetSlug;
+      }
+
       const response = await axios.get(
-        `/api/problems/${problemSlug}/hints/${hintType}/`
+        `/api/problems/${problemSlug}/hints/${hintType}/`,
+        { params }
       );
       return response.data;
     } catch (error) {

--- a/purplex/problems_app/views/hint_views.py
+++ b/purplex/problems_app/views/hint_views.py
@@ -9,6 +9,7 @@ from purplex.users_app.permissions import IsAdmin, IsAuthenticated, IsInstructor
 from purplex.utils.error_codes import ErrorCode, error_response
 
 from ..repositories import ProblemRepository
+from ..repositories.course_repository import CourseRepository
 from ..services.course_service import CourseService
 from ..services.hint_display_service import HintDisplayService
 from ..services.hint_service import AdminHintService, HintService
@@ -123,8 +124,13 @@ class ProblemHintDetailView(APIView):
             else:
                 return error_response(message, ErrorCode.SERVER_ERROR, 500)
 
-        # Record durable activity event for hint delivery
+        # Record durable activity event for hint delivery. Resolve to FK
+        # objects so queries can join on ActivityEvent.problem/course directly
+        # without JSON-extracting from payload.
         from purplex.submissions.activity_event_service import ActivityEventService
+
+        problem = ProblemRepository.get_problem_by_slug(slug)
+        course = CourseRepository.get_active_course(course_id) if course_id else None
 
         ActivityEventService.record_best_effort(
             user=request.user,
@@ -135,6 +141,8 @@ class ProblemHintDetailView(APIView):
                 "course_id": course_id,
                 "min_attempts": hint_data.get("min_attempts"),
             },
+            problem=problem,
+            course=course,
         )
 
         # Return successful response

--- a/tests/unit/test_activity_event_recording.py
+++ b/tests/unit/test_activity_event_recording.py
@@ -13,6 +13,9 @@ from rest_framework import status
 
 from purplex.submissions.models import ActivityEvent
 from tests.factories import (
+    CourseEnrollmentFactory,
+    CourseFactory,
+    CourseProblemSetFactory,
     EiplProblemFactory,
     ProbeableCodeProblemFactory,
     ProblemHintFactory,
@@ -153,7 +156,59 @@ class TestHintViewEventRecording:
 
         event = events.first()
         assert event.user == user
+        assert event.problem == problem
+        assert event.course is None
         assert event.payload["hint_type"] == "variable_fade"
+        assert event.payload["problem_slug"] == problem.slug
+
+    def test_hint_view_records_course_fk_when_course_context_provided(
+        self, api_client
+    ):
+        """When course_id is sent as a query param the resulting hint.view
+        ActivityEvent has both problem and course FKs populated.
+
+        This is what Kate's analysis pipeline relies on for per-course
+        attribution — without it, every hint.view row has course=None and
+        course assignment can only be inferred via CourseEnrollment joins.
+        """
+        user = UserFactory()
+        problem = EiplProblemFactory()
+        problem_set = ProblemSetFactory()
+        ProblemSetMembershipFactory(problem=problem, problem_set=problem_set, order=1)
+        course = CourseFactory()
+        CourseEnrollmentFactory(user=user, course=course)
+        CourseProblemSetFactory(course=course, problem_set=problem_set)
+        ProblemHintFactory(
+            problem=problem,
+            hint_type="variable_fade",
+            min_attempts=1,
+            content={"mappings": [{"from": "x", "to": "count"}]},
+        )
+        UserProgressFactory(
+            user=user,
+            problem=problem,
+            problem_set=problem_set,
+            course=course,
+            attempts=2,
+        )
+
+        api_client.force_authenticate(user=user)
+        url = reverse(
+            "problem_hint_detail",
+            kwargs={"slug": problem.slug, "hint_type": "variable_fade"},
+        )
+        response = api_client.get(
+            url,
+            {"problem_set_slug": problem_set.slug, "course_id": course.course_id},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        event = ActivityEvent.objects.get(event_type="hint.view")
+        assert event.user == user
+        assert event.problem == problem
+        assert event.course == course
+        assert event.payload["course_id"] == course.course_id
         assert event.payload["problem_slug"] == problem.slug
 
     def test_hint_view_no_event_on_error(self, api_client):


### PR DESCRIPTION
## Summary

`hint.view` ActivityEvents currently land with `course` and `problem` FKs **both NULL**, even when the request came from a course-context lab page. Verified on prod just now — 16 of 16 historical rows have `course_id: None` in payload and null FKs:

```
raw payload: {'course_id': None, 'hint_type': 'variable_fade', 'min_attempts': 1, 'problem_slug': 'lab-task1'}
user: davidsmith
problem FK: None
course FK: None
```

Two root causes, fixed in lockstep:

1. **Frontend gap** — `problemService.getHintContent()` didn't accept/forward the `{courseId, problemSetSlug}` context that the sibling `getHints()` already takes, so the backend received no `course_id` query param.
2. **Backend gap** — `ProblemHintDetailView` never resolved `slug`/`course_id` to `Problem`/`Course` objects before `record_best_effort()`, so even when the slug *was* known, the FK columns stayed NULL.

After this PR, `hint.view` rows have `course_id` populated AND the `event.course` / `event.problem` FKs are set, so Kate's analysis can `filter(course=c)` directly instead of JSON-extracting from payload or back-joining through `CourseEnrollment`.

## Changes

- `purplex/client/src/services/problemService.ts` — `getHintContent` accepts `context?: { courseId?, problemSetSlug? }`, forwards as query params (mirrors `getHints`).
- `purplex/client/src/components/HintButton.vue` — passes its existing `courseId`/`problemSetSlug` props through to `getHintContent` at both call sites (user-click and preload).
- `purplex/problems_app/views/hint_views.py` — resolves slug → Problem and course_id → Course after the access check passes, passes both to `record_best_effort` as kwargs.
- `tests/unit/test_activity_event_recording.py` — extends existing test (`event.problem == problem`) and adds a new test that supplies `course_id`, enrolls the user, and asserts both FKs resolve.

## Behavioral note

`HintService.get_hint_content` already enforces course enrollment when `course_id` is provided (`hint_service.py:200-208`). The frontend now sending `course_id` means a request from a non-enrolled user could turn from 200 into 403. In practice this closes an inconsistency — `getHints` (the metadata sibling) already applies the same gate, so the user has passed the enrollment check before the editor ever asks for content. Standalone (non-course) problems pass `undefined` and behave exactly as today.

## Out of scope

- **Prefetch noise**: `HintButton.loadHints()` preloads content for previously-used hints on mount, producing extra `hint.view` rows before any user click. With this PR those rows will have proper attribution, but they still fire automatically. Whether "view = served" or "view = user-initiated open" is a research-design call for Kate; tracked separately.
- **Backfill of historical rows**: the 16 pre-fix rows are my own test walkthroughs; the study hasn't started.

## Test plan

- [ ] CI green: unit + integration tests on 3.11 and 3.12
- [ ] After deploy, click a hint on COMPSCI101A → confirm new `hint.view` row has `payload.course_id = 'COMPSCI101A'` and `course_id` FK is non-null
- [ ] Confirm standalone-problem hint requests (no course context) still succeed with `course_id: None` in payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)