### PR TITLE
Include problem description in student problem-set payload

### DIFF
--- a/purplex/problems_app/repositories/problem_set_membership_repository.py
+++ b/purplex/problems_app/repositories/problem_set_membership_repository.py
@@ -133,6 +133,7 @@ class ProblemSetMembershipRepository(BaseRepository):
                 "id": problem.id,
                 "slug": problem.slug,
                 "title": problem.title,
+                "description": problem.description,
                 "difficulty": problem.difficulty,
                 "problem_type": problem.problem_type,
                 "is_active": problem.is_active,

--- a/purplex/problems_app/services/student_service.py
+++ b/purplex/problems_app/services/student_service.py
@@ -143,6 +143,7 @@ class StudentService:
                     # Core fields (all problem types)
                     "slug": problem["slug"],
                     "title": problem["title"],
+                    "description": problem["description"],
                     "difficulty": problem["difficulty"],
                     "problem_type": problem["problem_type"],
                     "order": membership["order"],


### PR DESCRIPTION
## Problem

On the `probeable-demo` course, both probeable problems render **"No question text provided. Please add a description in the admin panel."** even though their `description` is set in the DB.

## Root cause

The student course problem-set payload — built by `ProblemSetMembershipRepository.get_problem_set_memberships_with_categories` and assembled in `StudentService` — **omits the `description` field**.

`ProblemSet.vue` renders the description section (and the `noQuestionText` fallback) for any problem whose handler reports `display_config.show_reference_code === false`. The probeable handlers (`probeable_code`, `probeable_spec`) set `show_reference_code: False`, so the frontend hits that branch, finds no `description` in the payload, and shows the placeholder.

EiPL never tripped this because its handler sets `show_reference_code: True` (renders the code-editor branch instead). Probeable problems are the first type to combine `show_reference_code: False` with a course problem set, exposing the gap.

## Fix

Thread `description` through both layers:
- `problem_set_membership_repository.py` — add `description` to the problem dict.
- `student_service.py` — include `description` in the student payload.

`description` is a base `Problem` field (always present), so this is safe for all problem types and additive to the payload.

## Verification

`description` now flows: DB → repository dict → StudentService payload → `ProblemSet.vue` `v-if="...description"` renders the markdown prompt instead of the placeholder. (Could not run end-to-end pre-merge — only a production DB is available, intentionally untouched; will verify on the deployed course post-deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)