### PR TITLE
Make probeable display/input config authoritative and consistent

### DIFF
--- a/purplex/client/src/components/activities/inputs/ProbeableCodeInput.vue
+++ b/purplex/client/src/components/activities/inputs/ProbeableCodeInput.vue
@@ -52,6 +52,7 @@
         :show-gutter="true"
         :wrap="false"
         :theme="editorTheme"
+        :placeholder="placeholder"
       />
     </div>
     <button
@@ -149,7 +150,11 @@ const {
 
 const { t } = useI18n()
 
-const sectionLabel = t('problems.probeableCode.sectionLabel')
+const sectionLabel = computed(() => {
+  return props.problem?.display_config?.section_label || t('problems.probeableCode.sectionLabel')
+})
+
+const placeholder = computed(() => props.problem?.input_config?.placeholder || '')
 
 // Code editor logic
 const inputValue = computed({

--- a/purplex/client/src/components/activities/inputs/ProbeableSpecInput.vue
+++ b/purplex/client/src/components/activities/inputs/ProbeableSpecInput.vue
@@ -30,7 +30,7 @@
     <!-- NL Description Input -->
     <div class="section-header description-section-header">
       <div class="section-label">
-        {{ $t('problems.probeableSpec.describeFunction') }}
+        {{ describeFunctionLabel }}
       </div>
     </div>
     <span
@@ -54,6 +54,7 @@
         :show-gutter="false"
         :wrap="true"
         :theme="editorTheme"
+        :placeholder="placeholder"
       />
     </div>
     <button
@@ -154,6 +155,12 @@ const { t } = useI18n()
 const sectionLabel = computed(() => {
   return props.problem?.display_config?.section_label || t('problems.probeableSpec.sectionLabel')
 })
+
+const describeFunctionLabel = computed(() => {
+  return props.problem?.input_config?.label || t('problems.probeableSpec.describeFunction')
+})
+
+const placeholder = computed(() => props.problem?.input_config?.placeholder || '')
 
 // NL editor logic
 const inputValue = computed({

--- a/purplex/client/src/components/activities/inputs/shared/ProbePanel.vue
+++ b/purplex/client/src/components/activities/inputs/shared/ProbePanel.vue
@@ -20,8 +20,10 @@
               :value="probeInputs[param.name]"
               type="text"
               class="param-input"
-              :placeholder="param.type"
-              :aria-label="$t('problems.probe.paramAriaLabel', { name: param.name, type: param.type })"
+              :placeholder="param.type || $t('problems.probe.valuePlaceholder')"
+              :aria-label="param.type
+                ? $t('problems.probe.paramAriaLabel', { name: param.name, type: param.type })
+                : $t('problems.probe.paramAriaLabelNoType', { name: param.name })"
               :disabled="!canProbe || isExecuting"
               @input="$emit('update-input', param.name, ($event.target as HTMLInputElement).value)"
               @keydown.enter="!isExecuting && canProbe && hasValidInputs && $emit('execute-probe')"

--- a/purplex/client/src/features/editor/Editor.vue
+++ b/purplex/client/src/features/editor/Editor.vue
@@ -69,6 +69,7 @@ const props = withDefaults(defineProps<{
   markers?: EditorMarker[]
   tabTargetId?: string | null
   focusScopeSelector?: string | null
+  placeholder?: string
 }>(), {
   lang: 'python',
   theme: 'tomorrow_night',
@@ -84,7 +85,8 @@ const props = withDefaults(defineProps<{
   readOnly: false,
   markers: () => [],
   tabTargetId: null,
-  focusScopeSelector: null
+  focusScopeSelector: null,
+  placeholder: ''
 })
 
 const emit = defineEmits<{
@@ -154,7 +156,8 @@ function editorInit(editorInstance: AceEditor): void {
     highlightGutterLine: false,
     showPrintMargin: false,
     wrap: true,
-    indentedSoftWrap: false
+    indentedSoftWrap: false,
+    placeholder: props.placeholder
   })
 
   // Make editor container tabbable
@@ -357,6 +360,13 @@ watch(() => props.value, (newValue) => {
 watch(() => props.markers, () => {
   applyMarkers()
 }, { deep: true })
+
+/* Update placeholder text when the prop changes */
+watch(() => props.placeholder, (newPlaceholder) => {
+  if (editor.value) {
+    editor.value.setOption('placeholder', newPlaceholder)
+  }
+})
 
 // Expose editor instance if needed
 defineExpose({

--- a/purplex/client/src/features/editor/__tests__/Editor.test.ts
+++ b/purplex/client/src/features/editor/__tests__/Editor.test.ts
@@ -184,7 +184,8 @@ describe('Editor Component', () => {
         readOnly: false,
         markers: [],
         tabTargetId: null,
-        focusScopeSelector: null
+        focusScopeSelector: null,
+        placeholder: ''
       })
     })
 
@@ -230,7 +231,8 @@ describe('Editor Component', () => {
         highlightGutterLine: false,
         showPrintMargin: false,
         wrap: true,
-        indentedSoftWrap: false
+        indentedSoftWrap: false,
+        placeholder: ''
       })
     })
 

--- a/purplex/client/src/i18n/locales/en/problems.json
+++ b/purplex/client/src/i18n/locales/en/problems.json
@@ -211,6 +211,8 @@
       "tooltipDefault": "Query the oracle with these inputs",
       "srDuplicate": "These inputs were already probed. Result: {result}",
       "paramAriaLabel": "Enter value for {name} (type: {type})",
+      "paramAriaLabelNoType": "Enter value for {name}",
+      "valuePlaceholder": "value",
       "cachedResultAriaLabel": "Cached result: {result}"
     },
     "refute": {

--- a/purplex/client/src/i18n/locales/en/problems.json
+++ b/purplex/client/src/i18n/locales/en/problems.json
@@ -191,7 +191,7 @@
       "sectionLabel": "Discover Function Behavior and Replicate Implementation"
     },
     "probeableSpec": {
-      "sectionLabel": "Discover and explain the function",
+      "sectionLabel": "Discover and improve the specification",
       "describeFunction": "Describe What the Function Does"
     },
     "debugFix": {

--- a/purplex/client/src/i18n/locales/es/problems.json
+++ b/purplex/client/src/i18n/locales/es/problems.json
@@ -191,7 +191,7 @@
       "sectionLabel": "Descubre el Comportamiento de la Función y Replica la Implementación"
     },
     "probeableSpec": {
-      "sectionLabel": "Descubre y explica la función",
+      "sectionLabel": "Descubre y mejora la especificación",
       "describeFunction": "Describe Qué Hace la Función"
     },
     "debugFix": {

--- a/purplex/client/src/i18n/locales/es/problems.json
+++ b/purplex/client/src/i18n/locales/es/problems.json
@@ -211,6 +211,8 @@
       "tooltipDefault": "Consultar el oráculo con estas entradas",
       "srDuplicate": "Estas entradas ya fueron sondeadas. Resultado: {result}",
       "paramAriaLabel": "Ingresa valor para {name} (tipo: {type})",
+      "paramAriaLabelNoType": "Ingresa valor para {name}",
+      "valuePlaceholder": "valor",
       "cachedResultAriaLabel": "Resultado en caché: {result}"
     },
     "refute": {

--- a/purplex/problems_app/handlers/probeable_code/handler.py
+++ b/purplex/problems_app/handlers/probeable_code/handler.py
@@ -192,12 +192,24 @@ class ProbeableCodeHandler(ActivityHandler):
         cooldown_attempts = getattr(problem, "cooldown_attempts", 3)
         cooldown_refill = getattr(problem, "cooldown_refill", 5)
 
+        # Parameter names are always needed to render probe inputs, but when
+        # show_function_signature is off the types are hidden from the student.
+        parameters = (
+            _parse_function_params(problem.function_signature)
+            if problem.function_signature
+            else []
+        )
+        if not show_signature:
+            parameters = [{"name": p["name"], "type": ""} for p in parameters]
+
         return {
             "display": {
                 "show_reference_code": False,  # Don't show oracle code
                 "show_function_signature": show_signature,
                 "code_read_only": False,  # Code is editable
-                "section_label": "Discover the function behavior",
+                "section_label": (
+                    "Discover Function Behavior and Replicate Implementation"
+                ),
             },
             "input": {
                 "type": "probeable_code",
@@ -216,11 +228,7 @@ class ProbeableCodeHandler(ActivityHandler):
                     problem.function_signature if show_signature else None
                 ),
                 "function_name": problem.function_name,
-                "parameters": (
-                    _parse_function_params(problem.function_signature)
-                    if problem.function_signature
-                    else []
-                ),
+                "parameters": parameters,
             },
             "hints": {
                 "available": [],  # No traditional hints for this type

--- a/purplex/problems_app/handlers/probeable_spec/handler.py
+++ b/purplex/problems_app/handlers/probeable_spec/handler.py
@@ -260,6 +260,16 @@ class ProbeableSpecHandler(ActivityHandler):
         cooldown_attempts = getattr(problem, "cooldown_attempts", 3)
         cooldown_refill = getattr(problem, "cooldown_refill", 5)
 
+        # Parameter names are always needed to render probe inputs, but when
+        # show_function_signature is off the types are hidden from the student.
+        parameters = (
+            _parse_function_params(problem.function_signature)
+            if problem.function_signature
+            else []
+        )
+        if not show_signature:
+            parameters = [{"name": p["name"], "type": ""} for p in parameters]
+
         return {
             "display": {
                 "show_reference_code": False,  # Don't show oracle code
@@ -284,11 +294,7 @@ class ProbeableSpecHandler(ActivityHandler):
                     problem.function_signature if show_signature else None
                 ),
                 "function_name": problem.function_name,
-                "parameters": (
-                    _parse_function_params(problem.function_signature)
-                    if problem.function_signature
-                    else []
-                ),
+                "parameters": parameters,
             },
             "hints": {
                 "available": [],  # No traditional hints - probing is the discovery mechanism

--- a/purplex/problems_app/handlers/probeable_spec/handler.py
+++ b/purplex/problems_app/handlers/probeable_spec/handler.py
@@ -275,7 +275,7 @@ class ProbeableSpecHandler(ActivityHandler):
                 "show_reference_code": False,  # Don't show oracle code
                 "show_function_signature": show_signature,
                 "code_read_only": True,  # Read-only code display (if any)
-                "section_label": "Discover and explain the function",
+                "section_label": "Discover and improve the specification",
             },
             "input": {
                 "type": "probeable_spec",  # Combined probe + NL input

--- a/tests/unit/test_handlers_probeable_code.py
+++ b/tests/unit/test_handlers_probeable_code.py
@@ -313,6 +313,16 @@ class TestProbeableCodeConfig:
         problem.function_signature = "solve(x: int) -> int"
         config = handler.get_problem_config(problem)
         assert config["probe"]["function_signature"] is None
+        # Parameter names are still needed to render probe inputs, but their
+        # types are hidden when show_function_signature is off.
+        assert config["probe"]["parameters"] == [{"name": "x", "type": ""}]
+
+    def test_get_problem_config_signature_shown_includes_types(self, handler):
+        problem = MagicMock()
+        problem.show_function_signature = True
+        problem.function_signature = "solve(x: int) -> int"
+        config = handler.get_problem_config(problem)
+        assert config["probe"]["parameters"] == [{"name": "x", "type": "int"}]
 
     def test_get_problem_config_hints_disabled(self, handler, mock_problem):
         config = handler.get_problem_config(mock_problem)

--- a/tests/unit/test_handlers_probeable_spec.py
+++ b/tests/unit/test_handlers_probeable_spec.py
@@ -418,6 +418,16 @@ class TestProbeableSpecConfig:
         assert config["probe"]["mode"] == "explore"
         assert config["probe"]["max_probes"] == 10
         assert config["probe"]["function_signature"] == "f(x: int) -> int"
+        assert config["probe"]["parameters"] == [{"name": "x", "type": "int"}]
+
+    def test_get_problem_config_signature_hidden(self, handler):
+        problem = MagicMock()
+        problem.show_function_signature = False
+        problem.function_signature = "f(x: int) -> int"
+        config = handler.get_problem_config(problem)
+        assert config["probe"]["function_signature"] is None
+        # Names remain (needed for probe inputs); types are hidden.
+        assert config["probe"]["parameters"] == [{"name": "x", "type": ""}]
 
     def test_get_problem_config_segmentation_enabled(self, handler, mock_problem):
         mock_problem.segmentation_enabled = True


### PR DESCRIPTION
## Summary

A review of what students are shown for the two **probeable** problem varieties (Probeable Code, Probeable Spec) surfaced cases where the backend handler emits display/input config that the frontend ignores or applies inconsistently. This makes the handler config authoritative and consistent across both varieties.

## Changes

**1. Section label consistency**
`ProbeableCodeInput` hardcoded its section label and ignored `display_config.section_label` (which `ProbeableSpecInput` already honored). Both now read the backend value with the i18n string as fallback, and the code handler's default carries the informative label — so an instructor editing `section_label` now affects both varieties.

**2. Configured input label/placeholder now reach students**
The handler-configured `placeholder` (e.g. Spec's `"This function..."` scaffold) and `label` were never displayed. Added a `placeholder` prop to the shared `Editor` component (ACE's built-in `placeholder` option + live watcher) and wired the configured label + placeholder through both probeable inputs.

**3. `show_function_signature = False` now actually hides types**
Both handlers always emitted full parameters (name + type) and `ProbePanel` showed the type as the input placeholder, so the toggle was a no-op. Handlers now strip parameter **types** when the flag is off (names remain — they're needed to render the probe inputs), and `ProbePanel` falls back to a generic placeholder and a name-only aria label. Added `probe.valuePlaceholder` / `probe.paramAriaLabelNoType` to `en` and `es` locales.

**4. Spec section label reword**
"Discover and explain the function" → **"Discover and improve the specification"** (handler default + en/es fallbacks).

## Input-box titles after this PR
- **Probeable Code:** "Discover Function Behavior and Replicate Implementation"
- **Probeable Spec:** "Discover and improve the specification"

## Testing
- Backend: `ruff check` clean; 81 probeable handler unit tests pass, incl. 3 new assertions locking in the type-stripping behavior. Pre-commit hooks (ruff, ruff-format, bandit, detect-secrets) all pass.
- Frontend: eslint clean; 25 Editor + 23 handler-composable vitest specs pass (2 Editor assertions updated for the new `placeholder` prop); both locale JSONs validate.
- Not run: live-browser pass (seed demo data → Playwright snapshot) — Postgres/Redis were down locally, so DB-backed integration tests couldn't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)