### PR TITLE
Refine probeable prompt: separate standard instructions from the instructor prompt

### DIFF
--- a/purplex/client/src/components/activities/inputs/ProbeableCodeInput.vue
+++ b/purplex/client/src/components/activities/inputs/ProbeableCodeInput.vue
@@ -232,6 +232,7 @@ function handleSubmit() {
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
   line-height: 1.5;
+  text-align: left;
 }
 
 /* Divider between probe panel and editor */

--- a/purplex/client/src/components/activities/inputs/ProbeableCodeInput.vue
+++ b/purplex/client/src/components/activities/inputs/ProbeableCodeInput.vue
@@ -7,6 +7,11 @@
       </div>
     </div>
 
+    <!-- Standard per-type instructions (boilerplate for every probeable code problem) -->
+    <p class="probe-instructions">
+      {{ $t('problems.probeableCode.instructions') }}
+    </p>
+
     <!-- Probe Panel -->
     <ProbePanel
       :function-name="functionName"
@@ -219,6 +224,14 @@ function handleSubmit() {
   font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-secondary);
+}
+
+/* Standard per-type instruction line (muted helper text) */
+.probe-instructions {
+  margin: 0 var(--spacing-lg) var(--spacing-sm);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
 }
 
 /* Divider between probe panel and editor */

--- a/purplex/client/src/components/activities/inputs/ProbeableSpecInput.vue
+++ b/purplex/client/src/components/activities/inputs/ProbeableSpecInput.vue
@@ -236,6 +236,7 @@ function handleSubmit() {
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
   line-height: 1.5;
+  text-align: left;
 }
 
 .description-section-header {

--- a/purplex/client/src/components/activities/inputs/ProbeableSpecInput.vue
+++ b/purplex/client/src/components/activities/inputs/ProbeableSpecInput.vue
@@ -7,6 +7,11 @@
       </div>
     </div>
 
+    <!-- Standard per-type instructions (boilerplate for every probeable spec problem) -->
+    <p class="probe-instructions">
+      {{ $t('problems.probeableSpec.instructions') }}
+    </p>
+
     <!-- Probe Panel -->
     <ProbePanel
       :function-name="functionName"
@@ -223,6 +228,14 @@ function handleSubmit() {
   font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-secondary);
+}
+
+/* Standard per-type instruction line (muted helper text) */
+.probe-instructions {
+  margin: 0 var(--spacing-lg) var(--spacing-sm);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
 }
 
 .description-section-header {

--- a/purplex/client/src/i18n/locales/en/problems.json
+++ b/purplex/client/src/i18n/locales/en/problems.json
@@ -188,11 +188,13 @@
       "selectFirst": "Please select an answer before submitting"
     },
     "probeableCode": {
-      "sectionLabel": "Discover Function Behavior and Replicate Implementation"
+      "sectionLabel": "Discover Function Behavior and Replicate Implementation",
+      "instructions": "Probe the function with inputs of your choice to discover what it does, then write code that reproduces the same behavior."
     },
     "probeableSpec": {
       "sectionLabel": "Discover and improve the specification",
-      "describeFunction": "Describe What the Function Does"
+      "describeFunction": "Describe What the Function Does",
+      "instructions": "Probe the function with inputs of your choice to discover what it does, then explain in plain language what it does."
     },
     "debugFix": {
       "sectionLabel": "Fix the buggy code"

--- a/purplex/client/src/i18n/locales/en/problems.json
+++ b/purplex/client/src/i18n/locales/en/problems.json
@@ -189,12 +189,12 @@
     },
     "probeableCode": {
       "sectionLabel": "Discover Function Behavior and Replicate Implementation",
-      "instructions": "Probe the function with inputs of your choice to discover what it does, then write code that reproduces the same behavior."
+      "instructions": "Try inputs of your choice to discover what the function does, then write code that reproduces it."
     },
     "probeableSpec": {
       "sectionLabel": "Discover and improve the specification",
       "describeFunction": "Describe What the Function Does",
-      "instructions": "Probe the function with inputs of your choice to discover what it does, then explain in plain language what it does."
+      "instructions": "Try inputs of your choice to discover what the function does, then explain it in plain language."
     },
     "debugFix": {
       "sectionLabel": "Fix the buggy code"

--- a/purplex/client/src/i18n/locales/es/problems.json
+++ b/purplex/client/src/i18n/locales/es/problems.json
@@ -189,12 +189,12 @@
     },
     "probeableCode": {
       "sectionLabel": "Descubre el Comportamiento de la Función y Replica la Implementación",
-      "instructions": "Sondea la función con entradas de tu elección para descubrir qué hace, luego escribe código que reproduzca el mismo comportamiento."
+      "instructions": "Prueba entradas de tu elección para descubrir qué hace la función, luego escribe código que lo reproduzca."
     },
     "probeableSpec": {
       "sectionLabel": "Descubre y mejora la especificación",
       "describeFunction": "Describe Qué Hace la Función",
-      "instructions": "Sondea la función con entradas de tu elección para descubrir qué hace, luego explica en lenguaje sencillo qué hace."
+      "instructions": "Prueba entradas de tu elección para descubrir qué hace la función, luego explícalo en lenguaje sencillo."
     },
     "debugFix": {
       "sectionLabel": "Corrige el código con errores"

--- a/purplex/client/src/i18n/locales/es/problems.json
+++ b/purplex/client/src/i18n/locales/es/problems.json
@@ -188,11 +188,13 @@
       "selectFirst": "Por favor, selecciona una respuesta antes de enviar"
     },
     "probeableCode": {
-      "sectionLabel": "Descubre el Comportamiento de la Función y Replica la Implementación"
+      "sectionLabel": "Descubre el Comportamiento de la Función y Replica la Implementación",
+      "instructions": "Sondea la función con entradas de tu elección para descubrir qué hace, luego escribe código que reproduzca el mismo comportamiento."
     },
     "probeableSpec": {
       "sectionLabel": "Descubre y mejora la especificación",
-      "describeFunction": "Describe Qué Hace la Función"
+      "describeFunction": "Describe Qué Hace la Función",
+      "instructions": "Sondea la función con entradas de tu elección para descubrir qué hace, luego explica en lenguaje sencillo qué hace."
     },
     "debugFix": {
       "sectionLabel": "Corrige el código con errores"

--- a/purplex/problems_app/management/commands/seed_probeable_demo_courses.py
+++ b/purplex/problems_app/management/commands/seed_probeable_demo_courses.py
@@ -116,11 +116,11 @@ class Command(BaseCommand):
             slug="demo-probeable-code-transform",
             defaults={
                 "title": "Probe & Code: Mystery Transform",
+                # Instructor prompt only — the standard "probe it… then write code"
+                # instructions are rendered per-type by the frontend, not stored here.
                 "description": (
                     "A hidden function `transform` takes a list of integers and "
-                    "returns a new list. You can't see its body. Probe it with "
-                    "inputs of your choice to discover what it does, then write "
-                    "code that reproduces the same behavior."
+                    "returns a new list."
                 ),
                 "function_signature": "def transform(lst: list[int]) -> list[int]",
                 "function_name": "transform",
@@ -147,11 +147,11 @@ class Command(BaseCommand):
             slug="demo-probeable-spec-classify",
             defaults={
                 "title": "Probe & Explain: Mystery Classify",
+                # Instructor prompt only — the standard "probe it… then explain"
+                # instructions are rendered per-type by the frontend, not stored here.
                 "description": (
                     "A hidden function `classify` takes a single integer and "
-                    "returns a string. Probe it with inputs of your choice to "
-                    "discover the rule, then explain in plain language what it "
-                    "does. Your explanation is turned into code and tested."
+                    "returns a string."
                 ),
                 "function_signature": "def classify(n: int) -> str",
                 "function_name": "classify",


### PR DESCRIPTION
## Summary

Refines the student-facing probeable problem display so the instructor's problem statement and the
generic per-type instructions are cleanly separated, and the standard instruction line reads well.

Previously the seed `description` conflated the problem-specific instructor prompt with the generic
"probe it… then write code/explain" boilerplate, and an earlier callout redesign changed the platform's
design language (reverted — not part of this PR).

## Changes

- **Separate standard instructions from the instructor prompt.** Add per-type standard instruction
  strings (i18n, en/es) rendered automatically under the section label in `ProbeableCodeInput` /
  `ProbeableSpecInput` as muted helper text — boilerplate for every problem of that type, not stored
  per-problem. The instructor `description` now holds only the problem-specific prompt.
- **Trim the seed descriptions** (`seed_probeable_demo_courses.py`) to the instructor prompt only.
- **Left-align + reword the instruction line.** Reset the inherited global `#app { text-align: center }`
  on `.probe-instructions` so it reads as left-aligned helper text, and use the concise wording:
  - Code: "Try inputs of your choice to discover what the function does, then write code that reproduces it."
  - Spec: "Try inputs of your choice to discover what the function does, then explain it in plain language."

No design-language changes to the question box.

## Testing

- eslint + stylelint clean; frontend tests pass; both locale JSONs validate.
- Verified live on the seeded `probeable-demo` course (both Code and Spec demo problems): instructor
  prompt shows alone in the question box; the left-aligned standard instruction line renders under the
  section label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)