### PR TITLE
Fix test-case string-output grading: one authoritative type normalizer

### DIFF
--- a/purplex/client/src/composables/admin/__tests__/useTestCases.test.ts
+++ b/purplex/client/src/composables/admin/__tests__/useTestCases.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { withSetup } from '@/test/setup';
+import { parseTypeAnnotation } from '@/utils/typeSystem';
+import { useTestCases } from '../useTestCases';
+import type { FunctionParameter } from '../useFunctionSignature';
+import type { TestCaseDisplay } from '@/types';
+
+/**
+ * Integration tests for convertForBackend type-aware conversion (#136).
+ *
+ * The instructor authoring panel and the persisted DB value must carry the
+ * author's declared type. A str-typed function whose test case reads "123" must
+ * be sent as the string "123", not coerced to int 123 — otherwise students fail
+ * a correct string answer.
+ */
+
+function param(type: string): FunctionParameter {
+  return {
+    name: 'p',
+    type,
+    simplifiedType: type.toLowerCase().split('[')[0],
+    typeSpec: parseTypeAnnotation(type),
+  };
+}
+
+function makeCase(inputs: unknown[], expected_output: unknown): TestCaseDisplay {
+  return {
+    inputs,
+    expected_output,
+    description: '',
+    is_hidden: false,
+    is_sample: true,
+    order: 0,
+    error: null,
+  } as TestCaseDisplay;
+}
+
+describe('useTestCases.convertForBackend (type-aware)', () => {
+  it('keeps a numeric-looking expected_output as a string for a -> str function', () => {
+    const tc = withSetup(() => useTestCases());
+    tc.testCases.value = [makeCase(['456'], '123')];
+
+    const [out] = tc.convertForBackend([param('str')], 'str');
+
+    expect(out.expected_output).toBe('123');
+    expect(typeof out.expected_output).toBe('string');
+    // str-typed input argument is likewise preserved
+    expect(out.inputs[0]).toBe('456');
+    expect(typeof out.inputs[0]).toBe('string');
+  });
+
+  it('still coerces to int for an int-returning function', () => {
+    const tc = withSetup(() => useTestCases());
+    tc.testCases.value = [makeCase(['456'], '123')];
+
+    const [out] = tc.convertForBackend([param('int')], 'int');
+
+    expect(out.expected_output).toBe(123);
+    expect(typeof out.expected_output).toBe('number');
+    expect(out.inputs[0]).toBe(456);
+  });
+
+  it('falls back to auto-detection when no signature is passed (backward compatible)', () => {
+    const tc = withSetup(() => useTestCases());
+    tc.testCases.value = [makeCase([], '123')];
+
+    const [out] = tc.convertForBackend();
+
+    expect(out.expected_output).toBe(123);
+  });
+
+  it('round-trips: a stored string survives load -> save', () => {
+    const tc = withSetup(() => useTestCases());
+    // Simulate loading a persisted str expected_output of "123".
+    const loaded = tc.convertFromBackend([makeCase([], '123')]);
+    tc.testCases.value = loaded;
+
+    const [out] = tc.convertForBackend([], 'str');
+
+    expect(out.expected_output).toBe('123');
+    expect(typeof out.expected_output).toBe('string');
+  });
+});

--- a/purplex/client/src/composables/admin/useProblemEditor.ts
+++ b/purplex/client/src/composables/admin/useProblemEditor.ts
@@ -266,9 +266,14 @@ export const useProblemEditor = (options?: UseProblemEditorOptions): UseProblemE
         tags: form.form.tags,
       };
 
-      // Test cases - use composable's conversion (single source of truth)
+      // Test cases - use composable's conversion (single source of truth).
+      // Pass the declared signature so values are converted against the author's
+      // declared types, not guessed from text (see #136).
       if (config?.supports?.test_cases !== false) {
-        problemData.test_cases = testCases.convertForBackend();
+        problemData.test_cases = testCases.convertForBackend(
+          signature.functionParameters.value,
+          signature.returnType.value,
+        );
       }
 
       // Type-specific data via registry
@@ -323,7 +328,10 @@ export const useProblemEditor = (options?: UseProblemEditorOptions): UseProblemE
         description: '',
         function_name: extractFunctionName(),
         reference_solution: form.form.reference_solution,
-        test_cases: testCases.convertForBackend(),
+        test_cases: testCases.convertForBackend(
+          signature.functionParameters.value,
+          signature.returnType.value,
+        ),
       };
 
       // Use injected API if provided

--- a/purplex/client/src/composables/admin/useTestCases.ts
+++ b/purplex/client/src/composables/admin/useTestCases.ts
@@ -12,8 +12,8 @@ import { computed, type ComputedRef, type Ref, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { TestCaseDisplay, TestExecutionResult } from '@/types';
 import {
-  autoDetectAndConvert,
   autoDetectTypeFromInput,
+  convertWithDeclaredType,
   formatValueForInput,
   getPlaceholderForType,
   parseTypeAnnotation,
@@ -97,7 +97,10 @@ export interface UseTestCasesReturn {
 
   // Conversion methods
   /** Convert test cases for backend API */
-  convertForBackend: () => Array<{
+  convertForBackend: (
+    functionParameters?: FunctionParameter[],
+    returnType?: string,
+  ) => Array<{
     inputs: unknown[];
     expected_output: unknown;
     description: string;
@@ -228,7 +231,9 @@ export const useTestCases = (): UseTestCasesReturn => {
     }
 
     try {
-      const convertedValue = autoDetectAndConvert(rawString);
+      // Convert using the declared type so the value we validate matches the
+      // value convertForBackend will actually send (see #136).
+      const convertedValue = convertWithDeclaredType(rawString, expectedType);
       const typeSpec = parseTypeAnnotation(expectedType);
       const validationResult = validateValueAgainstType(convertedValue, typeSpec as TypeSpec);
       return validationResult.valid ? null : (validationResult.error ?? null);
@@ -339,7 +344,9 @@ export const useTestCases = (): UseTestCasesReturn => {
     }
 
     try {
-      const convertedValue = autoDetectAndConvert(rawString);
+      // Convert using the declared return type so validation matches what
+      // convertForBackend will send (see #136).
+      const convertedValue = convertWithDeclaredType(rawString, returnType);
       const typeSpec = parseTypeAnnotation(returnType);
       const validationResult = validateValueAgainstType(convertedValue, typeSpec as TypeSpec);
       return validationResult.valid ? null : (validationResult.error ?? null);
@@ -433,20 +440,25 @@ export const useTestCases = (): UseTestCasesReturn => {
   /**
    * Convert test cases for backend API
    */
-  const convertForBackend = (): Array<{
+  const convertForBackend = (
+    functionParameters: FunctionParameter[] = [],
+    returnType = 'Any',
+  ): Array<{
     inputs: unknown[];
     expected_output: unknown;
     description: string;
     order: number;
   }> => {
     return testCases.value.map(tc => {
-      const convertedInputs = (tc.inputs || []).map(rawValue => {
+      const convertedInputs = (tc.inputs || []).map((rawValue, i) => {
         if (rawValue === null || rawValue === undefined || !String(rawValue).trim()) {
           return null;
         }
         try {
           if (typeof rawValue === 'string') {
-            return autoDetectAndConvert(rawValue);
+            // Use the declared param type as the authority so a str-typed
+            // argument that looks numeric isn't coerced (see #136).
+            return convertWithDeclaredType(rawValue, functionParameters[i]?.type ?? 'Any');
           }
           return rawValue;
         } catch {
@@ -461,7 +473,7 @@ export const useTestCases = (): UseTestCasesReturn => {
       } else {
         try {
           if (typeof rawOutput === 'string') {
-            convertedOutput = autoDetectAndConvert(rawOutput);
+            convertedOutput = convertWithDeclaredType(rawOutput, returnType);
           } else {
             convertedOutput = rawOutput;
           }

--- a/purplex/client/src/utils/__tests__/typeSystem.test.ts
+++ b/purplex/client/src/utils/__tests__/typeSystem.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { convertWithDeclaredType } from '../typeSystem';
+
+/**
+ * Tests for convertWithDeclaredType — the type-aware conversion that closes the
+ * #136 class of bug: a str-typed field whose text looks numeric must NOT be
+ * coerced to a number.
+ */
+describe('convertWithDeclaredType', () => {
+  describe('str-typed fields are taken as string literals', () => {
+    it('keeps an unquoted numeric string as a string', () => {
+      const result = convertWithDeclaredType('123', 'str');
+      expect(result).toBe('123');
+      expect(typeof result).toBe('string');
+    });
+
+    it('preserves leading zeros (007 stays "007", not 7)', () => {
+      expect(convertWithDeclaredType('007', 'str')).toBe('007');
+    });
+
+    it('strips optional surrounding quotes', () => {
+      expect(convertWithDeclaredType('"123"', 'str')).toBe('123');
+      expect(convertWithDeclaredType("'hello'", 'str')).toBe('hello');
+    });
+
+    it('keeps a json-looking string as a string', () => {
+      expect(convertWithDeclaredType('true', 'str')).toBe('true');
+      expect(convertWithDeclaredType('[1, 2]', 'str')).toBe('[1, 2]');
+    });
+  });
+
+  describe('non-str declared types keep auto-detection', () => {
+    it('converts a numeric string to int for an int field', () => {
+      const result = convertWithDeclaredType('123', 'int');
+      expect(result).toBe(123);
+      expect(typeof result).toBe('number');
+    });
+
+    it('converts to float for a float field', () => {
+      expect(convertWithDeclaredType('3.14', 'float')).toBe(3.14);
+    });
+
+    it('converts to bool for a bool field', () => {
+      expect(convertWithDeclaredType('true', 'bool')).toBe(true);
+    });
+
+    it('converts to a list for a list field', () => {
+      expect(convertWithDeclaredType('[1, 2]', 'list')).toEqual([1, 2]);
+    });
+  });
+
+  describe('Any / unknown falls back to auto-detection (backward compatible)', () => {
+    it('auto-detects a numeric string as int when type is Any', () => {
+      expect(convertWithDeclaredType('123', 'Any')).toBe(123);
+    });
+
+    it('auto-detects when type is empty', () => {
+      expect(convertWithDeclaredType('123', '')).toBe(123);
+    });
+  });
+});

--- a/purplex/client/src/utils/typeSystem.ts
+++ b/purplex/client/src/utils/typeSystem.ts
@@ -1180,6 +1180,29 @@ export function autoDetectAndConvert(value: string): unknown {
   return value;
 }
 
+/**
+ * Convert a raw field value to a backend value using the DECLARED type as the
+ * authority, instead of guessing the type from the text.
+ *
+ * This closes the #136 class of bug: a `str`-typed field whose text happens to
+ * look numeric (e.g. `123`, `007`) must be sent as the string "123"/"007", not
+ * coerced to an int. `autoDetectAndConvert` alone is type-blind and would coerce
+ * it, silently mis-grading correct string answers.
+ *
+ * Behavior: when the declared type simplifies to `str`, the field text is taken
+ * as a string literal (only optional surrounding quotes are stripped). For every
+ * other declared type — and for `Any`/unknown — we fall back to the existing
+ * auto-detection so int/float/list/etc. keep working unchanged. Container/Optional
+ * types are intentionally left to auto-detection for now.
+ */
+export function convertWithDeclaredType(rawValue: string, declaredType: string): unknown {
+  const baseType = simplifyPythonType(declaredType || 'Any');
+  if (baseType === 'str') {
+    return pythonTypes.str.convert(rawValue);
+  }
+  return autoDetectAndConvert(rawValue);
+}
+
 // ===== ENHANCED TYPE FORMATTING =====
 
 export function formatTypeSpec(typeSpec: TypeSpec): string {

--- a/purplex/problems_app/services/test_case_service.py
+++ b/purplex/problems_app/services/test_case_service.py
@@ -37,12 +37,25 @@ class TestCaseService:
         """
         Get test cases formatted for code execution.
 
+        This is the single authoritative source of execution-ready test cases.
+        ``inputs`` and ``expected_output`` are ``JSONField``s, so the values
+        returned here are already native, deserialized Python objects (a stored
+        string ``"123"`` comes back as the str ``"123"``, not as JSON text).
+
+        Callers MUST use these values as-is and MUST NOT re-decode them (e.g. a
+        second ``json.loads`` on a value that "looks like" JSON). Re-decoding
+        corrupts legitimately-string outputs (``"123" -> 123``, ``"true" ->
+        True``) and silently diverges the student grading path from the
+        instructor authoring path. This invariant is enforced by
+        ``tests/unit/test_testcase_normalization.py``.
+
         Args:
             problem: The problem to get test cases for
             include_hidden: Whether to include hidden test cases
 
         Returns:
-            List of dictionaries with 'inputs' and 'expected_output' keys
+            List of dictionaries with 'inputs' and 'expected_output' keys,
+            already typed and ready for the grader.
         """
         test_cases = TestCaseRepository.get_problem_test_cases(
             problem=problem, include_hidden=include_hidden

--- a/purplex/problems_app/tasks/pipeline.py
+++ b/purplex/problems_app/tasks/pipeline.py
@@ -323,19 +323,6 @@ def test_variation_helper(
     # Store original test case IDs for later mapping
     test_case_ids = [tc.get("id") for tc in test_cases]
 
-    # Parse JSON fields if needed
-    for tc in test_cases:
-        if isinstance(tc["inputs"], str):
-            try:
-                tc["inputs"] = json.loads(tc["inputs"])
-            except (json.JSONDecodeError, TypeError):
-                pass
-        if isinstance(tc["expected_output"], str):
-            try:
-                tc["expected_output"] = json.loads(tc["expected_output"])
-            except (json.JSONDecodeError, TypeError):
-                pass
-
     # Test the code using shared Docker service (no cleanup needed)
     with SharedDockerServiceContext() as service:
         # Set user context for async task (no user context in celery tasks)
@@ -1523,19 +1510,6 @@ def execute_debug_fix_pipeline(
         )
         test_case_ids = [tc.get("id") for tc in test_cases]
 
-        # Parse JSON fields if needed
-        for tc in test_cases:
-            if isinstance(tc["inputs"], str):
-                try:
-                    tc["inputs"] = json.loads(tc["inputs"])
-                except (json.JSONDecodeError, TypeError):
-                    pass
-            if isinstance(tc["expected_output"], str):
-                try:
-                    tc["expected_output"] = json.loads(tc["expected_output"])
-                except (json.JSONDecodeError, TypeError):
-                    pass
-
         # Execute code in Docker
         with SharedDockerServiceContext() as service:
             service.set_user_context(f"debug_fix_{user_id}")
@@ -1873,19 +1847,6 @@ def execute_probeable_code_pipeline(
             problem, include_hidden=True
         )
         test_case_ids = [tc.get("id") for tc in test_cases]
-
-        # Parse JSON fields if needed
-        for tc in test_cases:
-            if isinstance(tc["inputs"], str):
-                try:
-                    tc["inputs"] = json.loads(tc["inputs"])
-                except (json.JSONDecodeError, TypeError):
-                    pass
-            if isinstance(tc["expected_output"], str):
-                try:
-                    tc["expected_output"] = json.loads(tc["expected_output"])
-                except (json.JSONDecodeError, TypeError):
-                    pass
 
         # Execute code in Docker
         with SharedDockerServiceContext() as service:

--- a/tests/integration/test_testcase_string_output_grading.py
+++ b/tests/integration/test_testcase_string_output_grading.py
@@ -1,0 +1,266 @@
+"""
+Regression tests for string-typed ``expected_output`` test cases.
+
+Reproduces the reported bug: a problem about strings has test cases whose
+expected output is a *numeric-looking string* (e.g. the string ``"123"``).
+Such a test case **passes in the instructor authoring panel** but **fails for
+students**.
+
+Root cause (verified, see issue #136 for the related frontend angle):
+
+    ``TestCase.expected_output`` is a Django ``JSONField`` — values are already
+    deserialized to native Python types on read, so a stored string ``"123"``
+    comes back as the Python ``str`` ``"123"`` (the final value).
+
+    The STUDENT grading path then runs ``json.loads()`` on that value a *second*
+    time (``pipeline.py`` "Parse JSON fields if needed" block, duplicated at the
+    debug-fix and probeable-code pipelines). ``json.loads("123")`` returns the
+    int ``123`` — a double-decode that corrupts the type.
+
+    The AUTHORING path (``AdminTestProblemView``) forwards the request body
+    straight to the grader with **no** such re-parse, so it keeps the string.
+
+The downstream grader ``compare_results`` is type-strict (str != int), so the
+student's correct string answer ``"123"`` is marked FAILED against the corrupted
+int ``123`` — while the identical author-side run passes. That asymmetry is the
+"super weird" symptom.
+
+These tests assert on the payload *handed to the grader* (the real defect site),
+not on the in-Docker verdict, so they are fast and hermetic. ``compare_results``'s
+strictness — which is correct and must NOT be weakened — is covered separately in
+``tests/unit/test_docker_execution_service.py::TestTestRunnerComparison``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.factories import (
+    EiplProblemFactory,
+    ProbeableCodeProblemFactory,
+    ProblemSetFactory,
+    ProblemSetMembershipFactory,
+    TestCaseFactory,
+    UserFactory,
+    UserProfileFactory,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _capture_test_cases(mock_service):
+    """Return the ``test_cases`` list passed to ``service.test_solution(...)``.
+
+    Signature is ``test_solution(code, function_name, test_cases)`` (positional).
+    """
+    assert mock_service.test_solution.called, "grader was never invoked"
+    return mock_service.test_solution.call_args.args[2]
+
+
+# =============================================================================
+# Student grading path — the bug. These currently FAIL (the value is coerced).
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestStudentPathCoercesStringExpectedOutput:
+    """The student grading path must hand the grader the author's *string*,
+    not a json.loads-coerced int/float/bool."""
+
+    def test_variation_helper_preserves_string_expected_output(self, db):
+        """Minimal repro through the shared loader+normalize path.
+
+        ``test_variation_helper`` loads test cases from the DB and applies the
+        exact "Parse JSON fields if needed" normalization used by the student
+        pipelines. A stored string ``"123"`` must reach the grader as ``str``.
+        """
+        from purplex.problems_app.tasks.pipeline import test_variation_helper
+
+        problem = EiplProblemFactory(
+            function_name="stringify",
+            function_signature="def stringify(n: int) -> str",
+            reference_solution="def stringify(n):\n    return str(n)",
+        )
+        # Author's intent: the function returns the STRING "123".
+        TestCaseFactory(problem=problem, inputs=[123], expected_output="123")
+
+        mock_result = {
+            "testsPassed": 1,
+            "totalTests": 1,
+            "success": True,
+            "results": [{"pass": True}],
+        }
+        with patch(
+            "purplex.problems_app.tasks.pipeline.SharedDockerServiceContext"
+        ) as MockCtx:
+            mock_service = MagicMock()
+            mock_service.test_solution.return_value = mock_result
+            MockCtx.return_value.__enter__.return_value = mock_service
+
+            test_variation_helper("def stringify(n):\n    return str(n)", problem.id, 0)
+
+        graded = _capture_test_cases(mock_service)[0]["expected_output"]
+        assert isinstance(graded, str), (
+            f"student path corrupted the type: expected str, got "
+            f"{type(graded).__name__} ({graded!r}) — json.loads double-decode"
+        )
+        assert graded == "123"
+
+    def test_probeable_code_pipeline_preserves_string_expected_output(self, db):
+        """The genuine student submission task (probeable-code) must not coerce."""
+        from purplex.problems_app.tasks.pipeline import (
+            execute_probeable_code_pipeline,
+        )
+
+        user = UserFactory()
+        UserProfileFactory(user=user)
+        problem = ProbeableCodeProblemFactory(
+            is_active=True,
+            function_name="stringify",
+            function_signature="def stringify(n: int) -> str",
+            reference_solution="def stringify(n):\n    return str(n)",
+        )
+        problem_set = ProblemSetFactory()
+        ProblemSetMembershipFactory(problem_set=problem_set, problem=problem)
+        TestCaseFactory(problem=problem, inputs=[123], expected_output="123")
+
+        mock_result = {
+            "testsPassed": 1,
+            "totalTests": 1,
+            "success": True,
+            "results": [{"pass": True}],
+        }
+        with (
+            patch(
+                "purplex.problems_app.tasks.pipeline.SharedDockerServiceContext"
+            ) as MockCtx,
+            patch("purplex.problems_app.tasks.pipeline.publish_progress"),
+            patch("purplex.problems_app.tasks.pipeline.publish_completion"),
+            patch("purplex.submissions.services.ProgressService.process_submission"),
+        ):
+            mock_service = MagicMock()
+            mock_service.test_solution.return_value = mock_result
+            MockCtx.return_value.__enter__.return_value = mock_service
+
+            execute_probeable_code_pipeline.apply(
+                args=[
+                    problem.id,
+                    "def stringify(n):\n    return str(n)",
+                    user.id,
+                    problem_set.id,
+                ]
+            )
+
+        graded = _capture_test_cases(mock_service)[0]["expected_output"]
+        assert isinstance(graded, str), (
+            f"student path corrupted the type: expected str, got "
+            f"{type(graded).__name__} ({graded!r})"
+        )
+        assert graded == "123"
+
+
+# =============================================================================
+# Authoring path — the control. These PASS today (no coercion happens here),
+# proving the asymmetry that makes the bug "pass in authoring, fail for student".
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestAuthoringPathPreservesStringExpectedOutput:
+    """The authoring 'Test Solution' endpoint forwards the string unchanged."""
+
+    def test_admin_test_problem_keeps_string_expected_output(self, admin_client):
+        payload = {
+            "function_name": "stringify",
+            "reference_solution": "def stringify(n):\n    return str(n)",
+            "test_cases": [{"inputs": [123], "expected_output": "123"}],
+        }
+        mock_result = {
+            "testsPassed": 1,
+            "totalTests": 1,
+            "success": True,
+            "results": [{"pass": True}],
+        }
+        with patch(
+            "purplex.problems_app.views.admin_views.SharedDockerServiceContext"
+        ) as MockCtx:
+            mock_service = MagicMock()
+            mock_service.test_solution.return_value = mock_result
+            MockCtx.return_value.__enter__.return_value = mock_service
+
+            response = admin_client.post(
+                "/api/admin/test-problem/", payload, format="json"
+            )
+
+        assert response.status_code == 200, response.content
+        graded = _capture_test_cases(mock_service)[0]["expected_output"]
+        # Control assertion: the authoring path leaves the string alone.
+        assert isinstance(graded, str)
+        assert graded == "123"
+
+
+# =============================================================================
+# The discrepancy, stated as one test: both panels must agree on the type.
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestAuthoringAndStudentPathsAgree:
+    """Both panels must hand the grader the *same* type for the same test case.
+
+    This is the user-visible "passes in authoring, fails for student" symptom,
+    expressed directly. Currently fails because the student path coerces.
+    """
+
+    def test_both_paths_grade_the_same_type(self, db, admin_client):
+        problem = ProbeableCodeProblemFactory(
+            is_active=True,
+            function_name="stringify",
+            function_signature="def stringify(n: int) -> str",
+            reference_solution="def stringify(n):\n    return str(n)",
+        )
+        TestCaseFactory(problem=problem, inputs=[123], expected_output="123")
+
+        mock_result = {
+            "testsPassed": 1,
+            "totalTests": 1,
+            "success": True,
+            "results": [{"pass": True}],
+        }
+
+        # --- Authoring path (inline request body, as the editor would POST) ---
+        with patch(
+            "purplex.problems_app.views.admin_views.SharedDockerServiceContext"
+        ) as MockCtx:
+            mock_service = MagicMock()
+            mock_service.test_solution.return_value = mock_result
+            MockCtx.return_value.__enter__.return_value = mock_service
+            admin_client.post(
+                "/api/admin/test-problem/",
+                {
+                    "function_name": "stringify",
+                    "reference_solution": problem.reference_solution,
+                    "test_cases": [{"inputs": [123], "expected_output": "123"}],
+                },
+                format="json",
+            )
+            authoring_type = type(
+                _capture_test_cases(mock_service)[0]["expected_output"]
+            )
+
+        # --- Student path (loaded from the persisted TestCase) ---
+        from purplex.problems_app.tasks.pipeline import test_variation_helper
+
+        with patch(
+            "purplex.problems_app.tasks.pipeline.SharedDockerServiceContext"
+        ) as MockCtx:
+            mock_service = MagicMock()
+            mock_service.test_solution.return_value = mock_result
+            MockCtx.return_value.__enter__.return_value = mock_service
+            test_variation_helper(problem.reference_solution, problem.id, 0)
+            student_type = type(_capture_test_cases(mock_service)[0]["expected_output"])
+
+        assert authoring_type is student_type, (
+            f"panels disagree on expected_output type: authoring graded a "
+            f"{authoring_type.__name__}, student graded a {student_type.__name__}"
+        )

--- a/tests/unit/test_docker_execution_service.py
+++ b/tests/unit/test_docker_execution_service.py
@@ -1638,6 +1638,35 @@ class TestTestRunnerComparison:
         assert compare_fn("1", 1) is False
         assert compare_fn(None, 0) is False
 
+    # -- String-output mis-grading consequence ---------------------------------
+    # These document WHY a string ``expected_output`` that gets coerced to a
+    # non-str (the json.loads double-decode in the student grading path, see
+    # tests/integration/test_testcase_string_output_grading.py) marks a correct
+    # answer FAILED. ``compare_results`` is intentionally type-strict and is the
+    # CORRECT side of this bug — it must NOT be weakened to paper over the
+    # upstream coercion. ``actual`` is the student's correct string answer;
+    # ``expected`` is the corrupted (coerced) stored value.
+
+    def test_string_answer_vs_coerced_int_fails(self, compare_fn):
+        """Author meant the string "123"; coercion stored int 123."""
+        assert compare_fn("123", 123) is False
+
+    def test_string_answer_vs_coerced_float_fails(self, compare_fn):
+        """Author meant the string "3.14"; coercion stored float 3.14."""
+        assert compare_fn("3.14", 3.14) is False
+
+    def test_string_answer_vs_coerced_bool_fails(self, compare_fn):
+        """Author meant the string "true"; coercion stored bool True."""
+        assert compare_fn("true", True) is False
+
+    def test_string_answer_vs_coerced_list_fails(self, compare_fn):
+        """Author meant the string "[1, 2]"; coercion stored list [1, 2]."""
+        assert compare_fn("[1, 2]", [1, 2]) is False
+
+    def test_matching_strings_still_pass(self, compare_fn):
+        """Control: when the type is preserved, the same answer grades correct."""
+        assert compare_fn("123", "123") is True
+
 
 # =============================================================================
 # Utilities and Edge Cases Tests

--- a/tests/unit/test_testcase_normalization.py
+++ b/tests/unit/test_testcase_normalization.py
@@ -1,0 +1,154 @@
+"""
+Architectural test: test-case data is normalized exactly once.
+
+``TestCase.inputs`` and ``TestCase.expected_output`` are ``JSONField``s. Django
+deserializes them to native Python objects on read, so a stored string ``"123"``
+comes back as the str ``"123"`` — that IS the final value, not JSON text awaiting
+a parse.
+
+Calling ``json.loads()`` on such a value a second time is a *double-decode* that
+silently corrupts legitimately-string outputs (``"123" -> 123``, ``"true" ->
+True``, ``"[1,2]" -> [1,2]``). When that re-decode lives in the student grading
+path but not the instructor authoring path, the two panels disagree: a test case
+passes in authoring and fails for students (see
+``tests/integration/test_testcase_string_output_grading.py``). This bug shipped
+twice; this test exists so it cannot ship a third time.
+
+RULE: no ``json.loads(...)`` on a test-case ``inputs``/``expected_output`` value
+anywhere downstream of the canonical loader
+(``TestCaseService.get_test_cases_for_testing``). Consume those values as-is.
+
+This mirrors the AST approach in ``tests/unit/test_repository_pattern.py`` (method-
+call detection, not import detection). Run with: ``pytest -m architecture``.
+"""
+
+import ast
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.architecture]
+
+
+class ReDecodeViolation(NamedTuple):
+    """A json.loads() applied to a test-case JSONField value."""
+
+    file: str
+    line: int
+    code: str
+
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+# Directories whose code consumes test cases for execution/grading. The canonical
+# loader lives in services; these are the layers that must trust its output.
+SCAN_DIRS = [
+    "purplex/problems_app/tasks",
+    "purplex/problems_app/services",
+    "purplex/problems_app/handlers",
+    "purplex/problems_app/views",
+    "purplex/submissions",
+]
+
+# Substrings in the (unparsed) json.loads argument that identify a test-case
+# field access. ``expected_output`` is unique enough to match bare; ``inputs`` is
+# only matched as a field access to avoid catching unrelated variables.
+TESTCASE_FIELD_MARKERS = (
+    "expected_output",
+    '["inputs"]',
+    "['inputs']",
+    ".inputs",
+)
+
+# Documented exceptions. Key: filename, Value: set of arg-substrings allowed.
+# There are intentionally NONE. Do NOT add files here to silence a failure —
+# remove the json.loads instead. The JSONField already gave you the value.
+EXCEPTIONS: dict[str, set[str]] = {}
+
+
+class ReDecodeVisitor(ast.NodeVisitor):
+    """Detect ``json.loads(<...inputs/expected_output...>)`` calls."""
+
+    def __init__(self) -> None:
+        self.violations: list[tuple[int, str]] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._is_json_loads(node.func) and node.args:
+            arg_src = ast.unparse(node.args[0])
+            if any(marker in arg_src for marker in TESTCASE_FIELD_MARKERS):
+                self.violations.append((node.lineno, f"json.loads({arg_src})"))
+        self.generic_visit(node)
+
+    @staticmethod
+    def _is_json_loads(func: ast.expr) -> bool:
+        # json.loads(...)
+        if isinstance(func, ast.Attribute) and func.attr == "loads":
+            return True
+        # loads(...)  (from json import loads)
+        return isinstance(func, ast.Name) and func.id == "loads"
+
+
+def find_redecode_violations(file_path: Path) -> list[ReDecodeViolation]:
+    try:
+        tree = ast.parse(file_path.read_text())
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    visitor = ReDecodeVisitor()
+    visitor.visit(tree)
+
+    allowed = EXCEPTIONS.get(file_path.name, set())
+    return [
+        ReDecodeViolation(file=str(file_path), line=line, code=code)
+        for line, code in visitor.violations
+        if not any(pattern in code for pattern in allowed)
+    ]
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _scan_files() -> list[Path]:
+    root = _project_root()
+    files: list[Path] = []
+    for rel in SCAN_DIRS:
+        base = root / rel
+        if base.exists():
+            files.extend(p for p in base.rglob("*.py") if p.name != "__init__.py")
+    return files
+
+
+class TestTestCaseNotReDecoded:
+    """Enforce single-normalization of test-case data."""
+
+    def test_no_json_loads_on_testcase_fields(self):
+        violations: list[ReDecodeViolation] = []
+        for py_file in _scan_files():
+            violations.extend(find_redecode_violations(py_file))
+
+        if violations:
+            root = _project_root()
+            report = "\n".join(
+                f"  {Path(v.file).relative_to(root)}:{v.line} — {v.code}"
+                for v in violations
+            )
+            pytest.fail(
+                "json.loads() called on test-case inputs/expected_output. These "
+                "are JSONField values — already deserialized by Django. Re-decoding "
+                "corrupts string outputs and diverges student grading from instructor "
+                "authoring. Use the value from "
+                "TestCaseService.get_test_cases_for_testing() as-is.\n\n"
+                f"{report}"
+            )
+
+    def test_detector_catches_a_known_violation(self):
+        """Positive control: the visitor must actually flag the bug pattern,
+        so this guard can't silently rot into a no-op."""
+        source = 'import json\njson.loads(tc["expected_output"])\n'
+        visitor = ReDecodeVisitor()
+        visitor.visit(ast.parse(source))
+        assert visitor.violations, "detector failed to flag a known re-decode"


### PR DESCRIPTION
## Problem

Test cases whose `expected_output` is a numeric/JSON-looking **string** (e.g. the string `"123"`) **passed in the instructor authoring panel but failed for students** — the "super weird" symptom.

## Root cause

`TestCase.inputs`/`expected_output` are `JSONField`s, so values are already deserialized to native Python on read (stored `"123"` → the `str` `"123"`). The **student** grading path then ran `json.loads()` on that value a *second* time, coercing `"123" → 123` (also `"true" → True`, `"[1,2]" → [1,2]`). The **authoring** path (`AdminTestProblemView`) did **not** re-parse, so the two panels silently disagreed; the type-strict grader (`compare_results`) then marked correct string answers FAILED.

This was the same class as #136 (type re-interpreted at a boundary), just on the backend.

## Changes

**Backend**
- Delete the 3 duplicated `json.loads` double-decode blocks in `pipeline.py`. `TestCaseService.get_test_cases_for_testing()` is now the single authoritative normalizer (values used as-is).
- New AST architecture test `tests/unit/test_testcase_normalization.py` — fails CI if `json.loads` is reintroduced on `inputs`/`expected_output` (mirrors `test_repository_pattern.py`).

**Frontend — closes #136**
- New `convertWithDeclaredType()` in `typeSystem.ts`; `convertForBackend` now converts test-case values against the declared function signature instead of guessing from text, so a `str`-typed field keeps `"123"`/`"007"` as strings. Two validators fixed to match. First Vitest coverage for `useTestCases`/`typeSystem`.

## Tests

| Suite | Result |
|---|---|
| `pytest -m architecture` | 51 passed (incl. 2 new) |
| `pytest -m "not slow"` | 2238 passed, 0 failed |
| Regression `test_testcase_string_output_grading.py` | 4 passed (was 3 failed → fix confirmed) |
| Frontend `npm run test` | 464 passed / 37 files |

The regression tests assert on the payload handed to the grader on **both** panels, so they pin the discrepancy directly.

## Notes
- `compare_results` strictness is correct and intentionally **unchanged** — the bug was upstream type corruption.
- Frontend `convertWithDeclaredType` is scoped to scalar `str`; `Optional[str]`/`Union` still auto-detect, but the backend fix makes any residual coercion fail *visibly in the authoring panel* rather than silently for students.
- Follow-up #150 (`needs-senior-review`) tracks write-time validation of test cases against the declared signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
