### PR TITLE
Improve sampler course: divide-with-edge-cases probeable + EiPL segmentation

### DIFF
--- a/purplex/problems_app/management/commands/seed_sampler_course.py
+++ b/purplex/problems_app/management/commands/seed_sampler_course.py
@@ -133,6 +133,46 @@ class Command(BaseCommand):
                     "            total += n\n"
                     "    return total"
                 ),
+                # Prompt segmentation analysis: few-shot examples that teach the
+                # grader what a high-level (relational) vs. line-by-line
+                # (multi-structural) explanation of sum_evens looks like. Segment
+                # text must be a verbatim substring of its example prompt, and
+                # code_lines are 1-indexed with no overlap across segments.
+                "segmentation_config": {
+                    "enabled": True,
+                    "threshold": 2,
+                    "examples": {
+                        "relational": {
+                            "prompt": (
+                                "Adds up all the even numbers in the list and "
+                                "returns the total."
+                            ),
+                            "segments": [
+                                "Adds up all the even numbers in the list and "
+                                "returns the total."
+                            ],
+                            "code_lines": [[1, 2, 3, 4, 5, 6]],
+                        },
+                        "multi_structural": {
+                            "prompt": (
+                                "Starts a total at zero. Loops over each number "
+                                "in the list. Checks if the number is even. If it "
+                                "is even, adds it to the total. Finally returns "
+                                "the total."
+                            ),
+                            "segments": [
+                                "Starts a total at zero.",
+                                "Loops over each number in the list.",
+                                "Checks if the number is even.",
+                                "If it is even, adds it to the total.",
+                                "Finally returns the total.",
+                            ],
+                            "code_lines": [[2], [3], [4], [5], [6]],
+                        },
+                    },
+                },
+                "segmentation_threshold": 2,
+                "requires_highlevel_comprehension": True,
                 "difficulty": "beginner",
                 "is_active": True,
                 "created_by": instructor,
@@ -185,17 +225,26 @@ class Command(BaseCommand):
         # 4. Probeable Code problem (probe hidden oracle -> write code)
         # ==================================================================
         probeable, created = ProbeableCodeProblem.objects.get_or_create(
-            slug="sampler-probeable-code-transform",
+            slug="sampler-probeable-code-divide",
             defaults={
-                "title": "Probe & Code: The Mystery Number Machine",
+                "title": "Probe & Code: Integer Divide",
                 "description": (
-                    "A hidden function `transform` takes one integer and returns "
-                    "one integer. Probe it with inputs to discover the rule, then "
-                    "write code that reproduces it."
+                    "Implement a function that divides two numbers: `divide(a, b)` "
+                    "returns `a` divided by `b`. Sounds simple — but the exact "
+                    "behavior has edge cases the description does not spell out. "
+                    "Probe the hidden function with your own inputs to discover how "
+                    "it handles the tricky cases (What happens when you divide by "
+                    "zero? Does it round, and which way?), then write code that "
+                    "reproduces it exactly."
                 ),
-                "function_signature": "def transform(n: int) -> int",
-                "function_name": "transform",
-                "reference_solution": ("def transform(n):\n    return n * 3 + 1"),
+                "function_signature": "def divide(a: int, b: int) -> int",
+                "function_name": "divide",
+                "reference_solution": (
+                    "def divide(a, b):\n"
+                    "    if b == 0:\n"
+                    "        return 0\n"
+                    "    return a // b"
+                ),
                 "show_function_signature": True,
                 "probe_mode": "explore",
                 "max_probes": 10,
@@ -207,7 +256,7 @@ class Command(BaseCommand):
             },
         )
         self._report(
-            "ProbeableCodeProblem", "sampler-probeable-code-transform", created
+            "ProbeableCodeProblem", "sampler-probeable-code-divide", created
         )
         probeable.categories.add(cat_sampler)
 
@@ -315,32 +364,42 @@ class Command(BaseCommand):
             ],
             probeable: [
                 {
-                    "inputs": [2],
-                    "expected_output": 7,
+                    "inputs": [6, 2],
+                    "expected_output": 3,
                     "is_sample": True,
                     "order": 0,
-                    "description": "transform(2) = 7",
+                    "description": "divide(6, 2) = 3 (clean division)",
                 },
                 {
-                    "inputs": [0],
-                    "expected_output": 1,
+                    "inputs": [20, 4],
+                    "expected_output": 5,
                     "is_sample": True,
                     "order": 1,
-                    "description": "transform(0) = 1",
+                    "description": "divide(20, 4) = 5 (clean division)",
                 },
                 {
-                    "inputs": [-1],
-                    "expected_output": -2,
+                    "inputs": [7, 2],
+                    "expected_output": 3,
                     "is_sample": False,
                     "order": 2,
-                    "description": "transform(-1) = -2",
+                    "description": "divide(7, 2) = 3 (edge: floor division, not 3.5)",
                 },
                 {
-                    "inputs": [10],
-                    "expected_output": 31,
+                    "inputs": [-7, 2],
+                    "expected_output": -4,
                     "is_sample": False,
                     "order": 3,
-                    "description": "transform(10) = 31",
+                    "description": (
+                        "divide(-7, 2) = -4 (edge: floor rounds toward negative "
+                        "infinity)"
+                    ),
+                },
+                {
+                    "inputs": [5, 0],
+                    "expected_output": 0,
+                    "is_sample": False,
+                    "order": 4,
+                    "description": "divide(5, 0) = 0 (edge: divide by zero returns 0)",
                 },
             ],
         }

--- a/purplex/problems_app/management/commands/seed_sampler_course.py
+++ b/purplex/problems_app/management/commands/seed_sampler_course.py
@@ -255,9 +255,7 @@ class Command(BaseCommand):
                 "created_by": instructor,
             },
         )
-        self._report(
-            "ProbeableCodeProblem", "sampler-probeable-code-divide", created
-        )
+        self._report("ProbeableCodeProblem", "sampler-probeable-code-divide", created)
         probeable.categories.add(cat_sampler)
 
         # ==================================================================


### PR DESCRIPTION
## Summary
Two fixes to the Question Types Sampler seed command (`seed_sampler_course`), aligning the committed source with content already corrected on production.

### 1. Probeable Code → "divide two numbers" with edge cases
The old task was a `transform` (3n+1) machine — too on-the-nose; probing basically handed over the answer's shape. Replaced with a **high-level** goal ("Implement a function that divides two numbers") where the *edge cases must be discovered by probing*. The oracle is `a // b`, guarded on `b == 0`, exposing **three edge cases** via hidden test cases:

- `divide(7, 2) = 3` — floor division, not 3.5
- `divide(-7, 2) = -4` — floor rounds toward −∞
- `divide(5, 0) = 0` — divide-by-zero returns 0 instead of crashing

Slug renamed `sampler-probeable-code-transform` → `sampler-probeable-code-divide`.

### 2. EiPL → add prompt segmentation analysis
The sampler EiPL shipped with `segmentation_config = {}`, so comprehension grading (relational vs. multi-structural) had **no few-shot examples** to ground it — unlike every other EiPL problem. Added `relational` + `multi_structural` examples tailored to the `sum_evens` reference code, matching the established schema (verbatim-substring segments, non-overlapping 1-indexed `code_lines`, threshold 2).

## Notes
- Both changes were already applied to the production DB directly; this PR makes a fresh re-seed / image rebuild reproduce that state rather than reverting to `transform`.
- Seed command remains idempotent (`get_or_create`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)